### PR TITLE
Add unixsock plugin to new build path.

### DIFF
--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -67,6 +67,7 @@ override_dh_auto_configure:
 	--enable-target_replace --enable-target_scale \
 	--enable-match_throttle_metadata_keys \
 	--enable-write_log \
+	--enable-unixsock \
 	--with-useragent="stackdriver_agent/$(debian_version)" \
 	--enable-java --with-java=/usr/lib/jvm/default-java \
 	--enable-redis --with-libhiredis \

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -202,6 +202,7 @@ export PATH=%{buildroot}/%{_prefix}/bin:$PATH
     --enable-target_replace --enable-target_scale \
     --enable-match_throttle_metadata_keys \
     --enable-write_log \
+    --enable-unixsock \
     --with-useragent="stackdriver_agent/%{version}-%{release}" \
     %{docker_flag} \
     %{java_flag} \


### PR DESCRIPTION
No extra dependencies needed to bundle plugin.