### PR TITLE
Add unixsock plugin to old debian build path

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -62,6 +62,7 @@ override_dh_auto_configure:
 	--enable-target_replace --enable-target_scale \
 	--enable-match_throttle_metadata_keys \
 	--enable-write_log \
+	--enable-unixsock \
 	--with-useragent="stackdriver_agent/$(debian_version)" \
 	--enable-java --with-java=/usr/lib/jvm/default-java \
 	--enable-redis --with-libhiredis \


### PR DESCRIPTION
No extra dependencies needed to bundle the plugin.