### PR TITLE
Add missing rpm-sign package in the Amazon image.

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -21,6 +21,7 @@ RUN yum update -y && yum install -y \
 	postgresql-devel \
 	python-devel \
 	rpm-build \
+	rpm-sign \
 	which \
 	yajl-devel
 


### PR DESCRIPTION
This was not needed on CentOS 6-based systems, because `rpm-build` depends on `rpm`, which provided `rpmsign`.  On CentOS 7 and company, `rpmsign` was pulled into a separate package, `rpm-sign`, which wasn't pulled in by our Amazon image.