### PR TITLE
Stop using LSB functions on RedHat.

### DIFF
--- a/rpm/stackdriver-agent
+++ b/rpm/stackdriver-agent
@@ -109,19 +109,19 @@ gen_config() {
         # See if the instance has the correct monitoring scopes.
         INSTANCE_SCOPES=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/scopes 2>/dev/null || /bin/true)
         if [ `echo "$INSTANCE_SCOPES" | grep -cE '(monitoring.write|monitoring|cloud-platform)$'` -lt 1 ]; then
-            log_failure_msg "The instance has neither the application default" \
+            echo >&2 "The instance has neither the application default" \
               "credentials file nor the correct monitoring scopes; Exiting."
             return 1
         fi
     else
-        log_progress_msg "Sufficient authentication scope found to talk to the" \
+        echo "Sufficient authentication scope found to talk to the" \
           "Stackdriver Monitoring API."
     fi
 
     echo "$AUTOGENERATE_HEADER" > $CONFIG
     local IID=$(get_instance_id)
     if [ -z "$IID" ]; then
-        log_warning_msg "Unable to discover instance id. Exiting."
+        echo >&2 "Unable to discover instance id. Exiting."
     else
         echo "Hostname \"$IID\"" >> $CONFIG
     fi


### PR DESCRIPTION
Reverts a change accidentally introduced in #5.