### PR TITLE
Disable mongodb plugin on Ubuntu 18.04 Bionic

### DIFF
--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -4,8 +4,7 @@ SHELL=/bin/bash
 ARCH := $(shell uname -m)
 DISTRO=$(shell lsb_release -a 2>/dev/null |grep Codename |awk {'printf $$2;'})
 debian_version := $(shell dpkg-parsechangelog | sed -n 's/^Version: //p')
-ENABLE_MONGO_FLAG="--enable-mongodb"
-WITH_OWN_LIBMONGOC_FLAG="--with-libmongoc=own"
+MONGO_FLAG=--enable-mongodb --with-libmongoc=own
 
 ifeq ($(DISTRO),stretch)
 HIREDIS=libhiredis0.13
@@ -23,8 +22,7 @@ DOCKER_FLAG="--enable-docker"
 endif
 
 ifeq ($(DISTRO),bionic)
-ENABLE_MONGO_FLAG=""
-WITH_OWN_LIBMONGOC_FLAG="--with-libmongoc=no"
+MONGO_FLAG=--with-libmongoc=no
 endif
 
 CFLAGS = -g
@@ -85,8 +83,7 @@ override_dh_auto_configure:
 	--enable-write_gcm \
 	--enable-debug \
 	$(DOCKER_FLAG) \
-	$(WITH_OWN_LIBMONGOC_FLAG) \
-	$(ENABLE_MONGO_FLAG)
+	$(MONGO_FLAG)
 
 # filter out shlib deps we don't want to force on people
 override_dh_shlibdeps:

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -4,6 +4,8 @@ SHELL=/bin/bash
 ARCH := $(shell uname -m)
 DISTRO=$(shell lsb_release -a 2>/dev/null |grep Codename |awk {'printf $$2;'})
 debian_version := $(shell dpkg-parsechangelog | sed -n 's/^Version: //p')
+ENABLE_MONGO_FLAG="--enable-mongodb"
+WITH_OWN_LIBMONGOC_FLAG="--with-libmongoc=own"
 
 ifeq ($(DISTRO),stretch)
 HIREDIS=libhiredis0.13
@@ -20,6 +22,11 @@ ifeq ($(DISTRO),xenial)
 DOCKER_FLAG="--enable-docker"
 endif
 
+ifeq ($(DISTRO),bionic)
+ENABLE_MONGO_FLAG=""
+WITH_OWN_LIBMONGOC_FLAG="--with-libmongoc=no"
+endif
+
 CFLAGS = -g
 
 %:
@@ -33,7 +40,6 @@ override_dh_auto_configure:
 	--disable-all-plugins \
 	--disable-static \
 	--disable-perl --without-libperl  --without-perl-bindings \
-	--with-libmongoc=own \
 	--enable-cpu \
 	--enable-df \
 	--enable-disk \
@@ -75,11 +81,12 @@ override_dh_auto_configure:
 	--enable-redis --with-libhiredis \
 	--enable-curl \
 	--enable-curl_json \
-	--enable-mongodb \
 	--enable-varnish \
 	--enable-write_gcm \
 	--enable-debug \
-	$(DOCKER_FLAG)
+	$(DOCKER_FLAG) \
+	$(WITH_OWN_LIBMONGOC_FLAG) \
+	$(ENABLE_MONGO_FLAG)
 
 # filter out shlib deps we don't want to force on people
 override_dh_shlibdeps:

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -4,7 +4,6 @@ SHELL=/bin/bash
 ARCH := $(shell uname -m)
 DISTRO=$(shell lsb_release -a 2>/dev/null |grep Codename |awk {'printf $$2;'})
 debian_version := $(shell dpkg-parsechangelog | sed -n 's/^Version: //p')
-MONGO_FLAG=--enable-mongodb --with-libmongoc=own
 
 ifeq ($(DISTRO),stretch)
 HIREDIS=libhiredis0.13
@@ -21,8 +20,12 @@ ifeq ($(DISTRO),xenial)
 DOCKER_FLAG="--enable-docker"
 endif
 
+# Disable MongoDB plugin for Ubuntu Bionic until the monitoring agent's bundled
+# libmongoc is updated to support OpenSSL 1.1
 ifeq ($(DISTRO),bionic)
-MONGO_FLAG=--with-libmongoc=no
+MONGO_FLAG=--disable-mongodb
+else 
+MONGO_FLAG=--enable-mongodb --with-libmongoc=own
 endif
 
 CFLAGS = -g

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -20,9 +20,9 @@ ifeq ($(DISTRO),xenial)
 DOCKER_FLAG="--enable-docker"
 endif
 
-# Disable MongoDB plugin for Ubuntu Bionic until the monitoring agent's bundled
-# libmongoc is updated to support OpenSSL 1.1
 ifeq ($(DISTRO),bionic)
+# Disable MongoDB plugin for Ubuntu Bionic until the monitoring agent's vendored
+# libmongoc is updated to support OpenSSL 1.1.
 MONGO_FLAG=--disable-mongodb
 else 
 MONGO_FLAG=--enable-mongodb --with-libmongoc=own


### PR DESCRIPTION
While building for Ubuntu 18.04, I ran into issues with the bundled version of libmongoc and changes to the openssl API in version 1.1. This PR allows us to temporarily disable libmongoc for Bionic builds, but continue using it for other platforms.