### PR TITLE
Add Dockerfile for Ubuntu 18.04 build container

### DIFF
--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+ && apt-get install -y \
+        autoconf \
+        automake \
+        bison \
+        debhelper \
+        debian-keyring \
+        default-jdk \
+        devscripts \
+        flex \
+        gcc \
+        git \
+        libcurl4-openssl-dev \
+        libhiredis-dev \
+        libltdl-dev \
+        libmysqlclient-dev \
+        libpq-dev \
+        libssl-dev \
+        libtool \
+        libvarnishapi-dev \
+        libyajl-dev \
+        lsb-release \
+        make \
+        pkg-config \
+        python-dev \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds the Dockerfile for an Ubuntu 18.04 build container. 