### PR TITLE
Install epel-release before anything else.

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -2,11 +2,11 @@ FROM amazonlinux:2016.09
 
 ADD http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el6/en/x86_64/rpmforge/RPMS/rpm-macros-rpmforge-0-6.el6.rf.noarch.rpm .
 RUN yum -y update \
+ && yum -y install epel-release \
  && yum -y install \
         autoconf \
         automake \
         bison \
-        epel-release \
         flex \
         gcc \
         git \

--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -1,11 +1,11 @@
 FROM centos:6
 
 RUN yum -y update \
+ && yum -y install epel-release \
  && yum -y install \
         autoconf \
         automake \
         bison \
-        epel-release \
         expect \
         flex \
         gcc \

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -1,11 +1,11 @@
 FROM centos:7
 
 RUN yum -y update \
+ && yum -y install epel-release \
  && yum -y install \
         autoconf \
         automake \
         bison \
-        epel-release \
         expect \
         flex \
         gcc \


### PR DESCRIPTION
This was undetected breakage from the initial migration.