### PR TITLE
Don't hard-code agent version in the Makefiles.

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -33,4 +33,4 @@ OUTPUT_DIR ?= result
 vendor-debs:
 
 clean:
-	rm -rf *.dsc *.deb *.tar.gz *.tar.bz2 collectd-$(VERSION) result apt
+	rm -rf *.dsc *.deb *.tar.gz *.tar.bz2 collectd-$(VERSION) collectd-$(VERSION).git result apt

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -72,4 +72,4 @@ get-netifaces: vendor-dirs
 vendor-rpms: get-yajl get-hiredis get-psutil get-netifaces
 
 clean:
-	rm -rf result *rpm collectd-5.5.2 *.tar.bz2 collectd-5.5.2.git *.tar.gz
+	rm -rf result *rpm collectd-$(VERSION) *.tar.bz2 collectd-$(VERSION).git *.tar.gz


### PR DESCRIPTION
This is a pre-requisite for building from newer agent versions.