### PR TITLE
Re-generate autotools scripts for RPM builds.

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -3,7 +3,6 @@ source:
 	# this is run from inside our collectd fork so we clone a clean copy to work off of
 	git clone ../../ collectd-$(VERSION).git
 	pushd collectd-$(VERSION).git ; \
-	./clean.sh && ./build.sh && git commit -a -m "Clean and build" ; \
 	git archive --format tar --prefix=collectd-$(VERSION)/ HEAD | gzip > ../collectd-$(VERSION).tar.gz  ; \
 	popd
 

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -167,6 +167,9 @@ pushd curl-%{curl_version}
 popd
 export PATH=%{buildroot}/%{_prefix}/bin:$PATH
 
+# re-generate build files
+./clean.sh && ./build.sh
+
 # install mongo-c-driver into mongodb-mongo-c-driver/build
 %configure CFLAGS="%{optflags} -DLT_LAZY_OR_NOW='RTLD_NOW|RTLD_GLOBAL' -Icurl-%{curl_version}/include" \
     --program-prefix=stackdriver- \


### PR DESCRIPTION
This subsumes #48 by doing this at build time.