### PR TITLE
Really support SLES 12 and SLES 15.

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -36,10 +36,11 @@ ARCH?=`uname -i`
 
 OUTPUT_DIR ?= result
 
-ifeq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)  # Avoid trying to rm . or ..
-DIR_TO_RM := $(OUTPUT_DIR)
+# Any realpath that ends with a . is in the current directory's parent tree.
+ifneq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)
+DIR_TO_RM :=  # Avoid trying to rm . or ..
 else
-DIR_TO_RM :=
+DIR_TO_RM := $(OUTPUT_DIR)
 endif
 
 clean:

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -23,17 +23,24 @@ srcpkg: source debian/rules
 	popd
 
 build: srcpkg
+	[ -n "$(DIR_TO_RM)" ] && rm -rf "$(DIR_TO_RM)" || true # return true so we don't error out because the test condition fails
 	pushd collectd-$(VERSION) ; \
 	debuild -us -uc; \
 	popd ; \
 	rm -rf collectd-$(VERSION)
+	mkdir -p $(OUTPUT_DIR)
+	[ "$(OUTPUT_DIR)" != "." ] && mv ./stackdriver-agent_*.deb $(OUTPUT_DIR)/ || true # return true so we don't error out because the test condition fails
 
 DISTRO?=`lsb_release -a 2>/dev/null |grep Codename |awk {'print $2;'}`
 ARCH?=`uname -i`
 
 OUTPUT_DIR ?= result
 
-vendor-debs:
+ifeq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)  # Avoid trying to rm . or ..
+DIR_TO_RM := $(OUTPUT_DIR)
+else
+DIR_TO_RM :=
+endif
 
 clean:
-	rm -rf *.dsc *.deb *.tar.gz *.tar.bz2 collectd-$(VERSION) collectd-$(VERSION).git result apt
+	rm -rf $(DIR_TO_RM) *.dsc *.deb *.tar.gz *.tar.bz2 collectd-$(VERSION) collectd-$(VERSION).git result apt

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -36,9 +36,8 @@ ARCH?=`uname -i`
 
 OUTPUT_DIR ?= result
 
-# Any realpath that ends with a . is in the current directory's parent tree.
-ifneq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)
-DIR_TO_RM :=  # Avoid trying to rm . or ..
+ifneq ($(findstring $(abspath $(OUTPUT_DIR)),$(CURDIR)),)
+DIR_TO_RM :=  # Avoid trying to rm any prefix of the current directory.
 else
 DIR_TO_RM := $(OUTPUT_DIR)
 endif

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -27,7 +27,7 @@ endif
 TOPDIR=/root/rpmbuild
 
 build: source vendor vendor-rpms
-	rm -rf $(OUTPUT_DIR)
+	[ -n "$(DIR_TO_RM)" ] && rm -rf "$(DIR_TO_RM)" || true # return true so we don't error out because the test condition fails
 	if [[ $(DISTRO) == "epel-6" || $(DISTRO) == amzn-* ]]; then \
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/hiredis*-0.10.1-3.*.rpm; \
 	fi
@@ -37,12 +37,18 @@ build: source vendor vendor-rpms
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/yajl-devel*.rpm; \
 	fi
 	rpmbuild --define "_topdir $(TOPDIR)" --define "_source_filedigest_algorithm md5" --define "_sourcedir $$(pwd)" --define "_srcrpmdir $$(pwd)" --define "collectd_version $(VERSION)" --define "package_version $(PKG_VERSION)" --define "build_num $(PKG_BUILD)" -ba stackdriver-agent.spec
-	mkdir $(OUTPUT_DIR)
+	mkdir -p $(OUTPUT_DIR)
 	cp $(TOPDIR)/RPMS/$(ARCH)/stackdriver-agent-*.rpm $(OUTPUT_DIR)/
 
 ARCH ?= `uname -m`
 
 OUTPUT_DIR ?= result
+
+ifeq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)  # Avoid trying to rm . or ..
+DIR_TO_RM := $(OUTPUT_DIR)
+else
+DIR_TO_RM :=
+endif
 
 ifeq ($(filter sles%,$(DISTRO)),)
 vendor-dirs:
@@ -86,4 +92,4 @@ vendor-rpms:; true
 endif
 
 clean:
-	rm -rf $(OUTPUT_DIR)/ *rpm collectd-$(VERSION) *.tar.bz2 collectd-$(VERSION).git *.tar.gz
+	rm -rf $(DIR_TO_RM) *rpm collectd-$(VERSION) *.tar.bz2 collectd-$(VERSION).git *.tar.gz

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -8,15 +8,16 @@ source:
 	git archive --format tar --prefix=collectd-$(VERSION)/ HEAD | gzip > ../stackdriver-agent-$(PKG_VERSION).orig.tar.gz  ; \
 	popd
 
-ifneq ($(filter epel-6 amzn-%,$(DISTRO)),)
+# $(filter) will return all matching entries from the first list, or empty if none match.
+ifneq ($(filter epel-6 amzn-%,$(DISTRO)),)  # If DISTRO is epel-6 or amzn-*.
 CURL_VERSION=7.34.0
 else
-ifeq ($(filter sles%,$(DISTRO)),)
+ifeq ($(filter sles%,$(DISTRO)),)  # If DISTRO is not sles*.
 CURL_VERSION=7.52.1
 endif
 endif
 
-ifeq ($(filter sles%,$(DISTRO)),)
+ifeq ($(filter sles%,$(DISTRO)),)  # If DISTRO is not sles*.
 vendor:
 	[ -f curl-$(CURL_VERSION).tar.bz2 ] || curl -O https://curl.haxx.se/download/curl-$(CURL_VERSION).tar.bz2
 	sha1sum -c curl-$(CURL_VERSION).sha1
@@ -44,13 +45,14 @@ ARCH ?= `uname -m`
 
 OUTPUT_DIR ?= result
 
-ifeq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)  # Avoid trying to rm . or ..
-DIR_TO_RM := $(OUTPUT_DIR)
+# Any realpath that ends with a . is in the current directory's parent tree.
+ifneq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)
+DIR_TO_RM :=  # Avoid trying to rm . or ..
 else
-DIR_TO_RM :=
+DIR_TO_RM := $(OUTPUT_DIR)
 endif
 
-ifeq ($(filter sles%,$(DISTRO)),)
+ifeq ($(filter sles%,$(DISTRO)),)  # If DISTRO is not sles*.
 vendor-dirs:
 	mkdir -p vendor-epel-6/x86_64 vendor-epel-6/src
 	# Amazon Linux 2016.09 can use el6 packages.

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -45,9 +45,8 @@ ARCH ?= `uname -m`
 
 OUTPUT_DIR ?= result
 
-# Any realpath that ends with a . is in the current directory's parent tree.
-ifneq ($(filter %.,$(shell realpath --relative-to . $(OUTPUT_DIR))),)
-DIR_TO_RM :=  # Avoid trying to rm . or ..
+ifeq ($(findstring $(abspath $(OUTPUT_DIR)),$(CURDIR)),)
+DIR_TO_RM :=  # Avoid trying to rm any prefix of the current directory.
 else
 DIR_TO_RM := $(OUTPUT_DIR)
 endif

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -11,17 +11,23 @@ source:
 ifneq ($(filter epel-6 amzn-%,$(DISTRO)),)
 CURL_VERSION=7.34.0
 else
+ifeq ($(filter sles%,$(DISTRO)),)
 CURL_VERSION=7.52.1
 endif
+endif
 
+ifeq ($(filter sles%,$(DISTRO)),)
 vendor:
 	[ -f curl-$(CURL_VERSION).tar.bz2 ] || curl -O https://curl.haxx.se/download/curl-$(CURL_VERSION).tar.bz2
 	sha1sum -c curl-$(CURL_VERSION).sha1
+else
+vendor:;true
+endif
 
-ARCH ?= `uname -m`
+TOPDIR=/root/rpmbuild
 
 build: source vendor vendor-rpms
-	rm -rf result
+	rm -rf $(OUTPUT_DIR)
 	if [[ $(DISTRO) == "epel-6" || $(DISTRO) == amzn-* ]]; then \
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/hiredis*-0.10.1-3.*.rpm; \
 	fi
@@ -30,11 +36,15 @@ build: source vendor vendor-rpms
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/yajl-1*.rpm; \
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/yajl-devel*.rpm; \
 	fi
-	rpmbuild --define "_source_filedigest_algorithm md5" --define "_sourcedir $$(pwd)" --define "_srcrpmdir $$(pwd)" --define "collectd_version $(VERSION)" --define "package_version $(PKG_VERSION)" --define "build_num $(PKG_BUILD)" -ba stackdriver-agent.spec
-	mkdir result
-	cp /root/rpmbuild/RPMS/$(ARCH)/stackdriver-agent-*.rpm result/
+	rpmbuild --define "_topdir $(TOPDIR)" --define "_source_filedigest_algorithm md5" --define "_sourcedir $$(pwd)" --define "_srcrpmdir $$(pwd)" --define "collectd_version $(VERSION)" --define "package_version $(PKG_VERSION)" --define "build_num $(PKG_BUILD)" -ba stackdriver-agent.spec
+	mkdir $(OUTPUT_DIR)
+	cp $(TOPDIR)/RPMS/$(ARCH)/stackdriver-agent-*.rpm $(OUTPUT_DIR)/
+
+ARCH ?= `uname -m`
 
 OUTPUT_DIR ?= result
+
+ifeq ($(filter sles%,$(DISTRO)),)
 vendor-dirs:
 	mkdir -p vendor-epel-6/x86_64 vendor-epel-6/src
 	# Amazon Linux 2016.09 can use el6 packages.
@@ -71,6 +81,9 @@ get-netifaces: vendor-dirs
 
 # Download packages which aren't necessarily in base repos.
 vendor-rpms: get-yajl get-hiredis get-psutil get-netifaces
+else
+vendor-rpms:; true
+endif
 
 clean:
-	rm -rf result *rpm collectd-$(VERSION) *.tar.bz2 collectd-$(VERSION).git *.tar.gz
+	rm -rf $(OUTPUT_DIR)/ *rpm collectd-$(VERSION) *.tar.bz2 collectd-$(VERSION).git *.tar.gz

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -45,7 +45,7 @@ ARCH ?= `uname -m`
 
 OUTPUT_DIR ?= result
 
-ifeq ($(findstring $(abspath $(OUTPUT_DIR)),$(CURDIR)),)
+ifneq ($(findstring $(abspath $(OUTPUT_DIR)),$(CURDIR)),)
 DIR_TO_RM :=  # Avoid trying to rm any prefix of the current directory.
 else
 DIR_TO_RM := $(OUTPUT_DIR)

--- a/rpm/stackdriver-agent
+++ b/rpm/stackdriver-agent
@@ -19,7 +19,14 @@
 ### END INIT INFO
 
 # Source function library.
-. /etc/init.d/functions
+if [[ -f /lib/lsb/init-functions ]]; then
+  . /lib/lsb/init-functions
+else
+  . /etc/init.d/functions
+  function start_daemon() {
+    daemon "$@"
+  }
+fi
 
 RETVAL=0
 ARGS=""
@@ -116,7 +123,7 @@ start () {
     fi
 
     if [ -r "$CONFIG" ]; then
-        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" daemon "$DAEMON" -C "$CONFIG" -P "$pidfile"
+        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" start_daemon "$DAEMON" -C "$CONFIG" -P "$pidfile"
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch /var/lock/subsys/$prog

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -1,6 +1,11 @@
 %global _hardened_build 1
 %global __provides_exclude_from .*/collectd/.*\\.so$
 
+%if 0%{?suse_version} > 0
+# we expect the distro suffix
+%global dist .sles12
+%endif
+
 # we have some references to the buildroot in the binaries for the include path
 %define __arch_install_post %{nil}
 
@@ -11,7 +16,11 @@
 %define _sysconfdir %{_prefix}/etc
 %define _confdir /etc/stackdriver
 %define _mandir %{_prefix}/man
+%if 0%{?suse_version} > 0
+%define _initddir /etc/init.d
+%else
 %define _initddir /etc/rc.d/init.d
+%endif
 
 # some things that we enable or not based on distro version
 %define docker_flag --disable-docker
@@ -23,8 +32,10 @@
 %define varnish 1
 %define java_plugin 1
 %define dep_filter 1
+%define bundle_curl 1
 %define curl_version 7.34.0
 %define java_version 1.6.0
+%define java_lib_location /usr/lib/jvm/java
 %define has_python36 0
 
 %if 0%{?rhel} >= 7
@@ -42,8 +53,20 @@
 %define bundle_yajl 1
 %endif
 
+%if 0%{?suse_version} > 0
+%define dep_filter 0
+%define bundle_curl 0
+%define java_version 1.7.0
+%define java_lib_location /usr/lib64/jvm/java
+%endif
+
 %if %{has_hiredis}
 %define redis_flag --enable-redis --with-libhiredis
+%endif
+
+%if %{bundle_curl}
+%define curl_include -Icurl-%{curl_version}/include
+%define libcurl_flag --with-libcurl=%{buildroot}/%{_prefix}
 %endif
 
 %if %{has_yajl}
@@ -65,7 +88,7 @@
 %endif
 
 %if %{java_plugin}
-%define java_flag --enable-java --with-java=/usr/lib/jvm/java
+%define java_flag --enable-java --with-java=%{java_lib_location}
 %endif
 
 Summary: Stackdriver system metrics collection daemon
@@ -77,22 +100,39 @@ Group: System Environment/Daemons
 URL: http://www.stackdriver.com/
 
 Source: stackdriver-agent-%{version}.orig.tar.gz
+%if %{bundle_curl}
 # embed libcurl so we know it's linked against openssl instead of
 # nss. this avoids problems of nss leaking with libcurl. sigh.
 Source1: curl-%{curl_version}.tar.bz2
+%endif
 Source200: stackdriver-agent
 Source201: collectd.conf
 Source202: stackdriver.sysconfig
+%if 0%{?suse_version} == 0
 BuildRequires: perl(ExtUtils::MakeMaker)
 BuildRequires: perl(ExtUtils::Embed)
+%endif
 %if ! %{has_python36}
 BuildRequires: python-devel
 %else
 BuildRequires: python36-devel
 %endif
 BuildRequires: libgcrypt-devel
-BuildRequires: autoconf, automake
+BuildRequires: autoconf, automake >= 1.13
+%if 0%{?suse_version} > 0
+BuildRequires: bison
+BuildRequires: flex
+BuildRequires: libtool
+BuildRequires: rpm-build
+%endif
+%if ! %{bundle_curl}
+BuildRequires: libcurl-devel
+%endif
+%if 0%{?suse_version} > 0
+BuildRequires: libmysqlclient-devel
+%else
 BuildRequires: mysql-devel
+%endif
 # this is in the main mysql package sometimes but -devel ends up
 # just depending on libs.
 BuildRequires: /usr/bin/mysql_config
@@ -110,9 +150,17 @@ BuildRequires: java-devel
 BuildRequires: hiredis-devel
 %endif
 %if %{has_yajl}
+%if 0%{?suse_version} > 0
+BuildRequires: libyajl-devel
+%else
 BuildRequires: yajl-devel
+%endif
 %if ! %{bundle_yajl}
+%if 0%{?suse_version} > 0
+Requires: libyajl2
+%else
 Requires: yajl
+%endif
 %endif
 %endif
 %if %{mongo}
@@ -131,8 +179,32 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %define    _use_internal_dependency_generator 0
 
-# NOTE: this will only work for EL6.  If we want to support EL5, we'll
-# have to do some more work
+%if ! %{dep_filter}
+##### This section has been copied from redhat/macros.
+# prevent anything matching from being scanned for provides
+%define filter_provides_in(P) %{expand: \
+%global __filter_prov_cmd %{?__filter_prov_cmd} %{__grep} -v %{-P} '%*' | \
+}
+
+# prevent anything matching from being scanned for requires
+%define filter_requires_in(P) %{expand: \
+%global __filter_req_cmd %{?__filter_req_cmd} %{__grep} -v %{-P} '%*' | \
+}
+
+# actually set up the filtering bits
+%define filter_setup %{expand: \
+%global _use_internal_dependency_generator 0 \
+%global __deploop() while read FILE; do echo "${FILE}" | /usr/lib/rpm/rpmdeps -%{1}; done | /bin/sort -u \
+%global __find_provides /bin/sh -c "%{?__filter_prov_cmd} %{__deploop P} %{?__filter_from_prov}" \
+%global __find_requires /bin/sh -c "%{?__filter_req_cmd}  %{__deploop R} %{?__filter_from_req}" \
+}
+##### End section
+%endif
+
+#%if 0%{?suse_version} > 0
+#%filter_provides_in .*/collectd/.*\.so$
+#%endif
+
 %if %{dep_filter}
 %filter_requires_in mysql
 %filter_requires_in postgresql
@@ -141,6 +213,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 %filter_requires_in varnish
 %filter_requires_in write_gcm
 %filter_requires_in java
+%filter_requires_in python
 %filter_setup
 %endif
 
@@ -151,10 +224,14 @@ sends them to the Stackdriver service.
 Currently includes collectd.
 
 %prep
+%setup -q -n collectd-%{collectd_version}
 # update for aarch64
+%if %{bundle_curl}
 %setup -q -n collectd-%{collectd_version} -a 1
+%endif
 
 %build
+%if %{bundle_curl}
 # build libcurl first
 pushd curl-%{curl_version}
 ./configure --prefix=%{buildroot}%{_prefix} --with-ssl --disable-threaded-resolver --enable-ipv6 \
@@ -163,19 +240,20 @@ pushd curl-%{curl_version}
 %{__make} %{?_smp_mflags}
 %{__make} install
 popd
+%endif
 export PATH=%{buildroot}/%{_prefix}/bin:$PATH
 
 # re-generate build files
 ./clean.sh && ./build.sh
 
 # install mongo-c-driver into mongodb-mongo-c-driver/build
-%configure CFLAGS="%{optflags} -DLT_LAZY_OR_NOW='RTLD_NOW|RTLD_GLOBAL' -Icurl-%{curl_version}/include" \
+%configure CFLAGS="%{optflags} -DLT_LAZY_OR_NOW='RTLD_NOW|RTLD_GLOBAL' %{?curl_include}" \
     --program-prefix=stackdriver- \
     --disable-all-plugins \
     --disable-static \
     --disable-perl --without-libperl  --without-perl-bindings \
     --with-libiptc \
-    --with-libcurl=%{buildroot}/%{_prefix} \
+    %{?libcurl_flag} \
     --enable-cpu \
     --enable-curl \
     --enable-df \
@@ -229,12 +307,14 @@ export PATH=%{buildroot}/%{_prefix}/bin:$PATH
 
 %install
 # we have to reinstall as %%install cleans the buildroot
+%if %{bundle_curl}
 pushd curl-%{curl_version}
 %{__make} install
 # now remove things to avoid unpackaged files
 rm -rf %{buildroot}/%{_prefix}/bin %{buildroot}/%{_prefix}/man
 rm -rf %{buildroot}/%{_prefix}/share %{buildroot}/%{_prefix}/lib*/pkgconfig
 popd
+%endif
 
 %{__rm} -rf contrib/SpamAssassin
 %{__make} install DESTDIR="%{buildroot}"

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -197,7 +197,7 @@ Requires(post): %insserv_prereq
 %endif
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
-%define    _use_internal_dependency_generator 0
+%define _use_internal_dependency_generator 0
 
 %if ! %{dep_filter}
 ##### This section has been copied from redhat/macros.
@@ -220,10 +220,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 }
 ##### End section
 %endif
-
-#%if 0%{?suse_version} > 0
-#%filter_provides_in .*/collectd/.*\.so$
-#%endif
 
 %filter_requires_in mysql
 %filter_requires_in postgresql

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -3,7 +3,12 @@
 
 %if 0%{?suse_version} > 0
 # we expect the distro suffix
+%if 0%{?suse_version} < 1500
 %global dist .sles12
+%endif
+%if 0%{?suse_version} >= 1500
+%global dist .sles15
+%endif
 %endif
 
 # we have some references to the buildroot in the binaries for the include path
@@ -56,8 +61,14 @@
 %if 0%{?suse_version} > 0
 %define dep_filter 0
 %define bundle_curl 0
-%define java_version 1.7.0
 %define java_lib_location /usr/lib64/jvm/java
+%if 0%{?suse_version} < 1500
+%define java_version 1.7.0
+%endif
+%if 0%{?suse_version} >= 1500
+# Yes, SLES really has underscores.
+%define java_version 1_8_0
+%endif
 %endif
 
 %if %{has_hiredis}

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -174,8 +174,14 @@ Requires: yajl
 %endif
 %endif
 %endif
-%if %{mongo}
+%if %{varnish}
+%if 0%{?suse_version} > 0
+BuildRequires: varnish-devel
+%else
 BuildRequires: varnish-libs-devel
+%endif
+%endif
+%if %{mongo}
 %if ! %{bundle_mongo}
 BuildRequires: mongo-c-driver-devel, cyrus-sasl-devel
 Requires: mongo-c-driver-libs

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -225,7 +225,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 #%filter_provides_in .*/collectd/.*\.so$
 #%endif
 
-%if %{dep_filter}
 %filter_requires_in mysql
 %filter_requires_in postgresql
 %filter_requires_in redis
@@ -235,7 +234,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 %filter_requires_in java
 %filter_requires_in python
 %filter_setup
-%endif
 
 %description
 The Stackdriver system metrics daemon collects system statistics and

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -186,6 +186,9 @@ Requires: sed
 Requires(preun): /sbin/chkconfig
 Requires(post): /sbin/chkconfig
 Requires(post): /bin/grep
+%if 0%{?suse_version} > 0
+Requires(post): %insserv_prereq
+%endif
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %define    _use_internal_dependency_generator 0
@@ -384,6 +387,10 @@ cp /usr/share/doc/yajl-1.0.7/COPYING yajl.COPYING
 %post
 /sbin/ldconfig
 /sbin/chkconfig --add stackdriver-agent
+%if 0%{?suse_version} > 0
+# Enable the service by default.
+%{fillup_and_insserv -f -y stackdriver-agent}
+%endif
 
 %preun
 if [ $1 -eq 0 ]; then

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -1,4 +1,5 @@
 %global _hardened_build 1
+# Not all platforms support __provides_exclude_from; see dep_filter below.
 %global __provides_exclude_from .*/collectd/.*\\.so$
 
 %if 0%{?suse_version} > 0
@@ -36,30 +37,33 @@
 %define bundle_mongo 1
 %define varnish 1
 %define java_plugin 1
-%define dep_filter 1
 %define bundle_curl 1
 %define curl_version 7.34.0
 %define java_version 1.6.0
 %define java_lib_location /usr/lib/jvm/java
 %define has_python36 0
+# Enabled for systems that don't support the __provides_exclude_from global.
+%define dep_filter 1
 
 %if 0%{?rhel} >= 7
 %define java_version 1.7.0
 %define curl_version 7.52.1
 %define docker_flag --enable-docker
+%define dep_filter 0
 %endif
 
 %if 0%{?rhel} >= 8
 %define java_version 1.8.0
 %define has_python36 1
+%define dep_filter 0
 %endif
 
 %if 0%{?amzn} >= 1
 %define bundle_yajl 1
+%define dep_filter 0
 %endif
 
 %if 0%{?suse_version} > 0
-%define dep_filter 0
 %define bundle_curl 0
 %define java_lib_location /usr/lib64/jvm/java
 %if 0%{?suse_version} < 1500
@@ -68,6 +72,7 @@
 %if 0%{?suse_version} >= 1500
 # Yes, SLES really has underscores.
 %define java_version 1_8_0
+%define dep_filter 0
 %endif
 %endif
 
@@ -199,7 +204,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %define _use_internal_dependency_generator 0
 
-%if ! %{dep_filter}
+%if 0%{?suse_version} > 0
 ##### This section has been copied from redhat/macros.
 # prevent anything matching from being scanned for provides
 %define filter_provides_in(P) %{expand: \
@@ -219,6 +224,10 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 %global __find_requires /bin/sh -c "%{?__filter_req_cmd}  %{__deploop R} %{?__filter_from_req}" \
 }
 ##### End section
+%endif
+
+%if %{dep_filter}
+%filter_provides_in .*/collectd/.*\.so$
 %endif
 
 %filter_requires_in mysql

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -129,7 +129,7 @@ BuildRequires: python-devel
 BuildRequires: python36-devel
 %endif
 BuildRequires: libgcrypt-devel
-BuildRequires: autoconf, automake >= 1.13
+BuildRequires: autoconf, automake
 %if 0%{?suse_version} > 0
 BuildRequires: bison
 BuildRequires: flex


### PR DESCRIPTION
Also make the RPM build honor the `OUTPUT_DIR` setting, and make the DEB builds a bit more uniform with the RPM ones.

This is a rebase of the `sles-build` branch on top of the latest `stackdriver-agent-5.5.2` (with version support), but with additional fixes that allow building all of the RPM packages from it. It encapsulates the SLES-specific bits into the main configs.

I will be doing some additional testing of this tomorrow, but this is ready for an initial review.