### PR TITLE
Clean up the build configs to ignore the collectd version setting.

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -4,16 +4,16 @@ SHELL=/bin/bash
 include VERSION
 
 source:
-	[ -d collectd-$(VERSION).git ] && rm -rf collectd-$(VERSION).git || true # return true so we don't error out because the test condition fails
+	[ -d collectd-pristine.git ] && rm -rf collectd-pristine.git || true # return true so we don't error out because the test condition fails
 	# this is run from inside our collectd fork so we clone a clean copy to work off of
-	git clone ../../ collectd-$(VERSION).git
-	pushd collectd-$(VERSION).git ; \
-	git archive --format tar --prefix=collectd-$(VERSION)/ HEAD | gzip > ../stackdriver-agent_$(PKG_VERSION).orig.tar.gz  ; \
+	git clone ../../ collectd-pristine.git
+	pushd collectd-pristine.git ; \
+	git archive --format tar --prefix=collectd-pristine/ HEAD | gzip > ../stackdriver-agent_$(PKG_VERSION).orig.tar.gz  ; \
 	popd
 
 srcpkg: source debian/rules
 	tar -xf stackdriver-agent_$(PKG_VERSION).orig.tar.gz
-	pushd collectd-$(VERSION) ; \
+	pushd collectd-pristine ; \
 	cp -r ../debian . ; \
 	DEBEMAIL="stackdriver-agents@google.com" DEBFULLNAME="Stackdriver Agents" dch --package stackdriver-agent --distribution $(DISTRO) -v $(PKG_VERSION)-$(PKG_BUILD).$(DISTRO) "Automated build" ; \
 	cat debian/changelog ; \
@@ -24,10 +24,10 @@ srcpkg: source debian/rules
 
 build: srcpkg
 	[ -n "$(DIR_TO_RM)" ] && rm -rf "$(DIR_TO_RM)" || true # return true so we don't error out because the test condition fails
-	pushd collectd-$(VERSION) ; \
+	pushd collectd-pristine ; \
 	debuild -us -uc; \
 	popd ; \
-	rm -rf collectd-$(VERSION)
+	rm -rf collectd-pristine
 	mkdir -p $(OUTPUT_DIR)
 	[ "$(OUTPUT_DIR)" != "." ] && mv ./stackdriver-agent_*.deb $(OUTPUT_DIR)/ || true # return true so we don't error out because the test condition fails
 
@@ -43,4 +43,4 @@ DIR_TO_RM := $(OUTPUT_DIR)
 endif
 
 clean:
-	rm -rf $(DIR_TO_RM) *.dsc *.deb *.tar.gz *.tar.bz2 collectd-$(VERSION) collectd-$(VERSION).git result apt
+	rm -rf $(DIR_TO_RM) *.dsc *.deb *.tar.gz *.tar.bz2 collectd-pristine collectd-pristine.git result apt

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,11 +1,11 @@
 include VERSION
 
 source:
-	[ -d collectd-$(VERSION).git ] && rm -rf collectd-$(VERSION).git || true # return true so we don't error out because the test condition fails
+	[ -d collectd-pristine.git ] && rm -rf collectd-pristine.git || true # return true so we don't error out because the test condition fails
 	# this is run from inside our collectd fork so we clone a clean copy to work off of
-	git clone ../../ collectd-$(VERSION).git
-	pushd collectd-$(VERSION).git ; \
-	git archive --format tar --prefix=collectd-$(VERSION)/ HEAD | gzip > ../stackdriver-agent-$(PKG_VERSION).orig.tar.gz  ; \
+	git clone ../../ collectd-pristine.git
+	pushd collectd-pristine.git ; \
+	git archive --format tar --prefix=collectd-pristine/ HEAD | gzip > ../stackdriver-agent-$(PKG_VERSION).orig.tar.gz  ; \
 	popd
 
 # $(filter) will return all matching entries from the first list, or empty if none match.
@@ -37,7 +37,7 @@ build: source vendor vendor-rpms
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/yajl-1*.rpm; \
 	  yum install -y vendor-$(DISTRO)/$(ARCH)/yajl-devel*.rpm; \
 	fi
-	rpmbuild --define "_topdir $(TOPDIR)" --define "_source_filedigest_algorithm md5" --define "_sourcedir $$(pwd)" --define "_srcrpmdir $$(pwd)" --define "collectd_version $(VERSION)" --define "package_version $(PKG_VERSION)" --define "build_num $(PKG_BUILD)" -ba stackdriver-agent.spec
+	rpmbuild --define "_topdir $(TOPDIR)" --define "_source_filedigest_algorithm md5" --define "_sourcedir $$(pwd)" --define "_srcrpmdir $$(pwd)" --define "package_version $(PKG_VERSION)" --define "build_num $(PKG_BUILD)" -ba stackdriver-agent.spec
 	mkdir -p $(OUTPUT_DIR)
 	cp $(TOPDIR)/RPMS/$(ARCH)/stackdriver-agent-*.rpm $(OUTPUT_DIR)/
 
@@ -93,4 +93,4 @@ vendor-rpms:; true
 endif
 
 clean:
-	rm -rf $(DIR_TO_RM) *rpm collectd-$(VERSION) *.tar.bz2 collectd-$(VERSION).git *.tar.gz
+	rm -rf $(DIR_TO_RM) *rpm collectd-pristine *.tar.bz2 collectd-pristine.git *.tar.gz

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -247,10 +247,10 @@ sends them to the Stackdriver service.
 Currently includes collectd.
 
 %prep
-%setup -q -n collectd-%{collectd_version}
+%setup -q -n collectd-pristine
 # update for aarch64
 %if %{bundle_curl}
-%setup -q -n collectd-%{collectd_version} -a 1
+%setup -q -n collectd-pristine -a 1
 %endif
 
 %build


### PR DESCRIPTION
(It was only used for naming the source checkout directory, anyway).