### PR TITLE
Flip init functions lookup path to fix service status and start commands not found issue.

### DIFF
--- a/rpm/stackdriver-agent
+++ b/rpm/stackdriver-agent
@@ -19,13 +19,13 @@
 ### END INIT INFO
 
 # Source function library.
-if [[ -f /lib/lsb/init-functions ]]; then
-  . /lib/lsb/init-functions
-else
+if [[ -f /etc/init.d/functions ]]; then
   . /etc/init.d/functions
   function start_daemon() {
     daemon "$@"
   }
+else
+  . /lib/lsb/init-functions
 fi
 
 RETVAL=0

--- a/rpm/stackdriver-agent
+++ b/rpm/stackdriver-agent
@@ -19,6 +19,9 @@
 ### END INIT INFO
 
 # Source function library.
+# Even though `/lib/lsb/init-functions` is the recommended path, we are using `/etc/init.d/functions`
+# as default. Because there is a bug is the way `service stackdriver-agent status` is implemented. It
+# does not work well with `/lib/lsb/init-functions`.
 if [[ -f /etc/init.d/functions ]]; then
   . /etc/init.d/functions
   function start_daemon() {


### PR DESCRIPTION
This fixes:

```
$ sudo service stackdriver-agent status
/etc/init.d/stackdriver-agent: line 155: status: command not found
```