### PR TITLE
Unify the DEB and RPM init scripts (mostly).

### DIFF
--- a/deb/debian/stackdriver-agent.init
+++ b/deb/debian/stackdriver-agent.init
@@ -101,7 +101,7 @@ check_config() {
 # return:
 #   0 if the daemon has been started
 #   2 if the daemon could not be started
-#   3 if the daemon was not supposed to be started
+#   3 if the daemon was not supposed to be started due to user configuration
 start() {
     GOOGLE_MONITORING_ENABLE=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-monitoring-enable 2>/dev/null)
     if [ -n "$GOOGLE_MONITORING_ENABLE" -a "$GOOGLE_MONITORING_ENABLE" = "0" ]; then
@@ -137,7 +137,7 @@ stop() {
 #   0 if the daemon has been restarted
 #   1 if the daemon could not be stopped
 #   2 if the daemon could not be started
-#   3 if the daemon was not supposed to be restarted
+#   3 if the daemon was not supposed to be restarted due to user configuration
 restart() {
     if ! check_config; then
         log_failure_msg "not restarting, configuration/credentials error"

--- a/deb/debian/stackdriver-agent.init
+++ b/deb/debian/stackdriver-agent.init
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 #
 # stackdriver-agent - start and stop the Stackdriver agent
 # http://www.stackdriver.com
@@ -24,8 +24,6 @@
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
-DISABLE=0
-
 DESC="Stackdriver metrics collection agent"
 NAME=stackdriver-agent
 DAEMON=/opt/stackdriver/collectd/sbin/stackdriver-collectd
@@ -33,15 +31,13 @@ DAEMON=/opt/stackdriver/collectd/sbin/stackdriver-collectd
 CONFIG=/etc/stackdriver/collectd.conf
 _PIDFILE=/var/run/stackdriver-agent.pid
 
-MAXWAIT=30
-
 JAVA_LIB_DIR=""
 
 # Gracefully exit if the package has been removed.
-test -x $DAEMON || exit 0
+test -x "$DAEMON" || exit 0
 
-if [ -r /etc/default/${NAME} ]; then
-    . /etc/default/${NAME}
+if [ -r "/etc/default/${NAME}" ]; then
+    . "/etc/default/${NAME}"
 fi
 
 if test "$ENABLE_COREFILES" == 1; then
@@ -73,19 +69,13 @@ if [ -n "$JAVA_LIB_DIR" ]; then
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$JAVA_LIB_DIR"
 fi
 
-gen_hostid() {
-    echo "Generating a host id"
-    uuidgen > /opt/stackdriver/hostid
-    return 0
-}
-
 # return:
 #   0 if config is fine
 #   1 if there is a syntax error
 #   2 if there is no configuration
 #   3 if the instance doesn't have the necessary credentials
 check_config() {
-    if test ! -e "$CONFIG"; then
+    if test ! -r "$CONFIG"; then
         return 2
     fi
     if ! LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" "$DAEMON" -t -C "$CONFIG"; then
@@ -110,19 +100,12 @@ check_config() {
 
 # return:
 #   0 if the daemon has been started
-#   1 if the daemon was already running
 #   2 if the daemon could not be started
 #   3 if the daemon was not supposed to be started
-d_start() {
-    if test "$DISABLE" != 0; then
-        # we get here during restart
-        log_progress_msg "disabled by /etc/default/$NAME"
-        return 3
-    fi
-
+start() {
     GOOGLE_MONITORING_ENABLE=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-monitoring-enable 2>/dev/null)
     if [ -n "$GOOGLE_MONITORING_ENABLE" -a "$GOOGLE_MONITORING_ENABLE" = "0" ]; then
-        log_warning_msg "Disabled via metadata"
+        log_warning_msg "disabled via metadata"
         return 3
     fi
 
@@ -132,64 +115,48 @@ d_start() {
     fi
 
     if ! check_config; then
-        log_failure_msg "Not starting, configuration/credentials error."
+        log_failure_msg "not starting, configuration/credentials error."
         return 3
     fi
 
-    if test "$USE_COLLECTDMON" == 1; then
-        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" start-stop-daemon --start --quiet --oknodo --pidfile "$_PIDFILE" \
-            --exec $COLLECTDMON_DAEMON -- -P "$_PIDFILE" -- -C "$CONFIG" \
-            || return 2
-    else
-        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" start-stop-daemon --start --quiet --oknodo --pidfile "$_PIDFILE" \
-            --exec "$DAEMON" -- -C "$CONFIG" -P "$_PIDFILE" \
-            || return 2
-    fi
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" \
+        start_daemon -p "$_PIDFILE" "$DAEMON" -C "$CONFIG" -P "$_PIDFILE" \
+        || return 2
     return 0
 }
 
-still_running_warning="
-WARNING: $NAME might still be running.
-In large setups it might take some time to write all pending data to
-the disk. You can adjust the waiting time in /etc/default/$NAME."
-
 # return:
 #   0 if the daemon has been stopped
-#   1 if the daemon was already stopped
-#   2 if daemon could not be stopped
-d_stop() {
-    PID=$( cat "$_PIDFILE" 2> /dev/null ) || true
-
-    start-stop-daemon --stop --quiet --oknodo --pidfile "$_PIDFILE"
-    rc="$?"
-
-    if test "$rc" -eq 2; then
-        return 2
-    fi
-
-    sleep 1
-    if test -n "$PID" && kill -0 $PID 2> /dev/null; then
-        i=0
-        while kill -0 $PID 2> /dev/null; do
-            i=$(( $i + 2 ))
-            echo -n " ."
-
-            if test $i -gt $MAXWAIT; then
-                log_progress_msg "$still_running_warning"
-                return 2
-            fi
-
-            sleep 2
-        done
-        return "$rc"
-    fi
-    return "$rc"
+#   1 if the daemon could not be stopped
+#   3 if the daemon was already stopped
+stop() {
+    killproc -p "$_PIDFILE" "$DAEMON"
 }
 
+# return:
+#   0 if the daemon has been restarted
+#   1 if the daemon could not be stopped
+#   2 if the daemon could not be started
+#   3 if the daemon was not supposed to be restarted
+restart() {
+    if ! check_config; then
+        log_failure_msg "not restarting, configuration/credentials error"
+        return 3
+    fi
+    stop
+    rc="$?"
+    case "$rc" in
+        0|3) ;;
+        *) return "$rc" ;;
+    esac
+    start
+}
+
+# See how we were called.
 case "$1" in
     start)
         log_daemon_msg "Starting $DESC" "$NAME"
-        d_start
+        start
         case "$?" in
             0|1) log_end_msg 0 ;;
             2) log_end_msg 1 ;;
@@ -199,48 +166,54 @@ case "$1" in
         ;;
     stop)
         log_daemon_msg "Stopping $DESC" "$NAME"
-        d_stop
+        stop
         case "$?" in
-            0|1) log_end_msg 0 ;;
-            2) log_end_msg 1 ;;
+            0|3) log_end_msg 0 ;;
+            *) log_end_msg 1 ;;
         esac
         ;;
     status)
-        status_of_proc -p "$_PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
+        pidofproc -p "$_PIDFILE" "$DAEMON" >/dev/null
+        rc="$?"
+        case "$rc" in
+            0) log_success_msg "$NAME is running" ;;
+            4) log_failure_msg "could not access PID file for $NAME" ;;
+            *) log_failure_msg "$NAME is not running" ;;
+        esac
+        exit "$rc"
         ;;
     restart|force-reload)
         log_daemon_msg "Restarting $DESC" "$NAME"
-        check_config
-        rc="$?"
-        if test "$rc" -eq 1; then
-            log_progress_msg "not restarting, configuration error"
-            log_end_msg 1
-            exit 1
-        fi
-        d_stop
+        restart
         rc="$?"
         case "$rc" in
-            0|1)
-                sleep 1
-                d_start
-                rc2="$?"
-                case "$rc2" in
-                    0|1) log_end_msg 0 ;;
-                    2) log_end_msg 1 ;;
-                    3) log_end_msg 255; true ;;
-                    *) log_end_msg 1 ;;
-                esac
-                ;;
-            *)
-                log_end_msg 1
-                ;;
+            0) log_end_msg 0 ;;
+            1|2) log_end_msg 1 ;;
+            3) log_end_msg 255; true ;;
+            *) log_end_msg 1 ;;
         esac
+        exit "$rc"
         ;;
-    genhostid)
-        gen_hostid
+    condrestart|try-restart)
+        log_daemon_msg "Trying to restart $DESC" "$NAME"
+        pidofproc -p "$_PIDFILE" "$DAEMON" >/dev/null
+        case "$rc" in
+            0) ;;
+            4) log_end_msg 1; exit "$rc" ;;
+            *) log_end_msg 255; true ;;
+        esac
+        restart
+        rc="$?"
+        case "$rc" in
+            0) log_end_msg 0 ;;
+            1|2) log_end_msg 1 ;;
+            3) log_end_msg 255; true ;;
+            *) log_end_msg 1 ;;
+        esac
+        exit "$rc"
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+        echo "Usage: $0 {start|stop|status|restart|force-reload|condrestart|try-restart}"
         exit 3
         ;;
 esac

--- a/rpm/stackdriver-agent
+++ b/rpm/stackdriver-agent
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# stackdriver-agent    Startup script for the Stackdriver agent
+# stackdriver-agent - start and stop the Stackdriver agent
 # chkconfig: 2345 86 15
 # description: System metrics collection agent for Stackdriver
 # processname: stackdriver-collectd
@@ -9,39 +9,89 @@
 # pidfile: /var/run/stackdriver-agent.pid
 
 ### BEGIN INIT INFO
-# Provides: stackdriver-agent
-# Required-Start: $local_fs $remote_fs $network $syslog $named
-# Required-Stop: $local_fs $remote_fs $network $syslog
+# Provides:          stackdriver-agent
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Should-Start:      $network $named $syslog $time
+# Should-Stop:       $network $named $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Short-Description: start and stop Stackdriver Agent
 # Description: The Stackdriver Agent is used with the Stackdriver monitoring SaaS service.
-# Default-Start: 2 3 4 5
-# Default-Stop: 0 1 6
 ### END INIT INFO
 
 # Source function library.
 if [[ -f /lib/lsb/init-functions ]]; then
-  . /lib/lsb/init-functions
+    . /lib/lsb/init-functions
 else
-  . /etc/init.d/functions
-  function start_daemon() {
-    daemon "$@"
-  }
+    . /etc/init.d/functions
+    # Fake the necessary LSB functions.
+    function start_daemon() {
+        local -a daemon_flags
+        while [[ "$1" != "${1##-}" ]]; do
+            case "$1" in
+                -f) daemon_flags+=(--force); shift;;
+                -p) daemon_flags+=(--pidfile "$2"); shift 2;;
+                -n) daemon_flags+=("$2"); shift 2;;  # Assume +/-number.
+                *) break;;
+            esac
+        done
+        daemon "${daemon_flags[@]}" "$@"
+    }
+    function log_success_msg() {
+        echo -n "$@"
+        log_end_msg 0
+    }
+    function log_warning_msg() {
+        echo -n "$@"
+        log_end_msg 255
+    }
+    function log_failure_msg() {
+        echo -n "$@"
+        log_end_msg 1
+    }
 fi
+# Define helper LSB functions.
+function log_daemon_msg() {
+    echo -n "$1:${2:+ $2}"
+}
+function log_end_msg() {
+    if [[ $1 -eq 0 ]]; then
+        echo "."
+    elif [[ $1 -eq 255 ]]; then
+        echo " (warning)."
+    else
+        echo " failed!"
+    fi
+    return $1
+}
+function log_progress_msg() {
+    echo " $@"
+}
 
-RETVAL=0
-ARGS=""
-prog="stackdriver-collectd"
-pidfile=/var/run/stackdriver-agent.pid
-CONFIG=/etc/stackdriver/collectd.conf
+DESC="Stackdriver metrics collection agent"
+NAME=stackdriver-agent
 DAEMON=/opt/stackdriver/collectd/sbin/stackdriver-collectd
+
+CONFIG=/etc/stackdriver/collectd.conf
+_PIDFILE=/var/run/stackdriver-agent.pid
 
 JAVA_LIB_DIR=""
 
-if [ -r /etc/default/$prog ]; then
-    . /etc/default/$prog
+# Gracefully exit if the package has been removed.
+test -x "$DAEMON" || exit 0
+
+if [ -r "/etc/default/${NAME}" ]; then
+    . "/etc/default/${NAME}"
+elif [ -r "/etc/default/${DAEMON##*/}" ]; then
+    . "/etc/default/${DAEMON##*/}"
 fi
 if [ -r /etc/sysconfig/stackdriver ]; then
     . /etc/sysconfig/stackdriver
+fi
+
+if test "$ENABLE_COREFILES" == 1; then
+    ulimit -c unlimited
 fi
 
 # Attempt to discover the location of the Java libraries.
@@ -68,19 +118,13 @@ if [ -n "$JAVA_LIB_DIR" ]; then
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$JAVA_LIB_DIR"
 fi
 
-gen_hostid() {
-    echo "Generating a host id"
-    uuidgen > /opt/stackdriver/hostid
-    return 0
-}
-
 # return:
 #   0 if config is fine
 #   1 if there is a syntax error
 #   2 if there is no configuration
 #   3 if the instance doesn't have the necessary credentials
 check_config() {
-    if test ! -e "$CONFIG"; then
+    if test ! -r "$CONFIG"; then
         return 2
     fi
     if ! LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" "$DAEMON" -t -C "$CONFIG"; then
@@ -92,24 +136,26 @@ check_config() {
         # See if the instance has the correct monitoring scopes.
         INSTANCE_SCOPES=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/scopes 2>/dev/null || /bin/true)
         if [ `echo "$INSTANCE_SCOPES" | grep -cE '(monitoring.write|monitoring|cloud-platform)$'` -lt 1 ]; then
-            echo >&2 "The instance has neither the application default" \
+            log_failure_msg "The instance has neither the application default" \
               "credentials file nor the correct monitoring scopes; Exiting."
             return 3
         fi
     else
-        echo "Sufficient authentication scope found to talk to the" \
+        log_progress_msg "Sufficient authentication scope found to talk to the" \
           "Stackdriver Monitoring API."
     fi
     return 0
 }
 
-start () {
-    echo -n $"Starting $prog: "
-
+# return:
+#   0 if the daemon has been started
+#   2 if the daemon could not be started
+#   3 if the daemon was not supposed to be started
+start() {
     GOOGLE_MONITORING_ENABLE=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-monitoring-enable 2>/dev/null)
     if [ -n "$GOOGLE_MONITORING_ENABLE" -a "$GOOGLE_MONITORING_ENABLE" = "0" ]; then
-        echo "Disabled via metadata"
-        return 0
+        log_warning_msg "disabled via metadata"
+        return 3
     fi
 
     # allow setting a proxy
@@ -118,57 +164,107 @@ start () {
     fi
 
     if ! check_config; then
-        echo >&2 "Not starting, configuration/credentials error."
-        return 1
+        log_failure_msg "not starting, configuration/credentials error."
+        return 3
     fi
 
-    if [ -r "$CONFIG" ]; then
-        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" start_daemon "$DAEMON" -C "$CONFIG" -P "$pidfile"
-        RETVAL=$?
-        echo
-        [ $RETVAL -eq 0 ] && touch /var/lock/subsys/$prog
-    else
-        echo "Can't read agent configuration file: $CONFIG"
-        RETVAL=1
-    fi
-    return $RETVAL
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/stackdriver/collectd/lib64:/opt/stackdriver/collectd/lib" \
+        start_daemon -p "$_PIDFILE" "$DAEMON" -C "$CONFIG" -P "$_PIDFILE" \
+        || return 2
+    return 0
 }
 
-stop () {
-    echo -n $"Stopping $prog: "
-    killproc $prog
-    RETVAL=$?
-    echo
+# return:
+#   0 if the daemon has been stopped
+#   1 if the daemon could not be stopped
+#   3 if the daemon was already stopped
+stop() {
+    killproc -p "$_PIDFILE" "$DAEMON"
+}
 
-    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$prog
+# return:
+#   0 if the daemon has been restarted
+#   1 if the daemon could not be stopped
+#   2 if the daemon could not be started
+#   3 if the daemon was not supposed to be restarted
+restart() {
+    if ! check_config; then
+        log_failure_msg "not restarting, configuration/credentials error"
+        return 3
+    fi
+    stop
+    rc="$?"
+    case "$rc" in
+        0|3) ;;
+        *) return "$rc" ;;
+    esac
+    start
 }
 
 # See how we were called.
 case "$1" in
-  start)
-    start
-    ;;
-  stop)
-    stop
-    ;;
-  status)
-    status -p $pidfile $prog
-    ;;
-  restart|reload)
-    stop
-    start
-    ;;
-  condrestart)
-    [ -f /var/lock/subsys/$prog ] && stop && start || :
-    ;;
-  genhostid)
-    gen_hostid
-    ;;
-  *)
-    echo $"Usage: $0 {start|stop|status|restart|reload|condrestart|genhostid}"
-    exit 1
+    start)
+        log_daemon_msg "Starting $DESC" "$NAME"
+        start
+        case "$?" in
+            0|1) log_end_msg 0 ;;
+            2) log_end_msg 1 ;;
+            3) log_end_msg 255; true ;;
+            *) log_end_msg 1 ;;
+        esac
+        ;;
+    stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        stop
+        case "$?" in
+            0|3) log_end_msg 0 ;;
+            *) log_end_msg 1 ;;
+        esac
+        ;;
+    status)
+        pidofproc -p "$_PIDFILE" "$DAEMON" >/dev/null
+        rc="$?"
+        case "$rc" in
+            0) log_success_msg "$NAME is running" ;;
+            4) log_failure_msg "could not access PID file for $NAME" ;;
+            *) log_failure_msg "$NAME is not running" ;;
+        esac
+        exit "$rc"
+        ;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        restart
+        rc="$?"
+        case "$rc" in
+            0) log_end_msg 0 ;;
+            1|2) log_end_msg 1 ;;
+            3) log_end_msg 255; true ;;
+            *) log_end_msg 1 ;;
+        esac
+        exit "$rc"
+        ;;
+    condrestart|try-restart)
+        log_daemon_msg "Trying to restart $DESC" "$NAME"
+        pidofproc -p "$_PIDFILE" "$DAEMON" >/dev/null
+        case "$rc" in
+            0) ;;
+            4) log_end_msg 1; exit "$rc" ;;
+            *) log_end_msg 255; true ;;
+        esac
+        restart
+        rc="$?"
+        case "$rc" in
+            0) log_end_msg 0 ;;
+            1|2) log_end_msg 1 ;;
+            3) log_end_msg 255; true ;;
+            *) log_end_msg 1 ;;
+        esac
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart|force-reload|condrestart|try-restart}"
+        exit 3
+        ;;
 esac
 
-exit $?
-
-# vim:syntax=sh
+# vim: syntax=sh noexpandtab sw=4 ts=4 :

--- a/rpm/stackdriver-agent
+++ b/rpm/stackdriver-agent
@@ -150,7 +150,7 @@ check_config() {
 # return:
 #   0 if the daemon has been started
 #   2 if the daemon could not be started
-#   3 if the daemon was not supposed to be started
+#   3 if the daemon was not supposed to be started due to user configuration
 start() {
     GOOGLE_MONITORING_ENABLE=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-monitoring-enable 2>/dev/null)
     if [ -n "$GOOGLE_MONITORING_ENABLE" -a "$GOOGLE_MONITORING_ENABLE" = "0" ]; then
@@ -186,7 +186,7 @@ stop() {
 #   0 if the daemon has been restarted
 #   1 if the daemon could not be stopped
 #   2 if the daemon could not be started
-#   3 if the daemon was not supposed to be restarted
+#   3 if the daemon was not supposed to be restarted due to user configuration
 restart() {
     if ! check_config; then
         log_failure_msg "not restarting, configuration/credentials error"


### PR DESCRIPTION
Fixes the breakage introduced by #71, and includes the following changes:

- Add ENABLE_COREFILES to the RPM script
- Use pidfile to properly manage (start/stop) the daemon in the RPM script
  - Remove the now-redundant lockfile code
- Allow using /etc/default/stackdriver-agent in the RPM script
- Implement try_restart in the DEB script
- Change the RPM script to use force-reload instead of reload
- Remove unused legacy genhostid command
- Remove broken and unused collectdmon support from the DEB script
- Remove unused "wait-for-stop" functionality from the DEB script
- Remove unused "disable via defaults" functionality from the DEB script