### PR TITLE
Fix SLES 12 Missing Dependency by using libhiredis0.13 

### DIFF
--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -20,7 +20,6 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         libyajl2 \
         libyajl-devel \
         libmysqlclient-devel \
-        libhiredis0_13 \
         make \
         openssl-devel \
         postgresql-devel \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,6 +1,7 @@
 FROM opensuse/leap:42.3
 
 RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/Apache.repo \
+ && zypper addrepo https://download.opensuse.org/repositories/server:database/SLE_15/server:database.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install \
         autoconf \
@@ -18,6 +19,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         libyajl2 \
         libyajl-devel \
         libmysqlclient-devel \
+        libhiredis0_13 \
         make \
         openssl-devel \
         postgresql-devel \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,7 +1,7 @@
 FROM opensuse/leap:42.3
 
 RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/Apache.repo \
- # Add SLES 15 repo to install libhiredis0_13
+ # Add SLES 15 repo to install libhiredis0_13 from hiredis-devel
  && zypper addrepo https://download.opensuse.org/repositories/server:database/SLE_15/server:database.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/leap:42.3
 
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/SLE_12_SP3/devel:libraries:c_c++.repo \
+RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/Apache.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install \
         autoconf \
@@ -28,9 +28,9 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_
         varnish-devel \
         wget \
         which \
- && wget https://ftp.gwdg.de/pub/opensuse/repositories/home%3A/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.92.1.noarch.rpm \
- && rpm --force -Uvh automake-1.16.1-lp151.92.1.noarch.rpm \
- && rm automake-1.16.1-lp151.92.1.noarch.rpm \
+ && wget https://ftp.gwdg.de/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.93.1.noarch.rpm \
+ && rpm --force -Uvh automake-1.16.1-lp151.93.1.noarch.rpm \
+ && rm automake-1.16.1-lp151.93.1.noarch.rpm \
  # Pretend we are on SLES 12.
  && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,6 +1,7 @@
 FROM opensuse/leap:42.3
 
 RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/Apache.repo \
+ # Add SLES 15 repo to install libhiredis0_13
  && zypper addrepo https://download.opensuse.org/repositories/server:database/SLE_15/server:database.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install \


### PR DESCRIPTION
Install libhiredis.so.0.13 in the build container as SLES 12 only has 0.13 