### PR TITLE
Remove support for deprecated plugins

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -23,11 +23,9 @@ RUN yum -y update \
         perl-devel \
         perl-ExtUtils-Embed \
         pkgconfig \
-        postgresql-devel \
         python-devel \
         rpm-build \
         rpm-sign \
-        varnish-libs-devel \
         which \
         yajl-devel \
  && rpm -Uvh rpm-macros-rpmforge*.rpm \

--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update -y \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libssl-dev \
         libtool \
         libyajl-dev \

--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update -y \
         flex \
         gcc \
         git \
-        libbson-dev \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \

--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -18,12 +18,10 @@ RUN apt-get update -y \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
-        libmongoc-dev \
         libmysqlclient-dev \
         libpq-dev \
         libssl-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_buster/Dockerfile
+++ b/build/x86_64_buster/Dockerfile
@@ -17,12 +17,10 @@ RUN apt-get -y update \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
-        libmongoc-dev \
         libpq-dev \
         libpq5 \
         libssl-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_buster/Dockerfile
+++ b/build/x86_64_buster/Dockerfile
@@ -17,8 +17,6 @@ RUN apt-get -y update \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
-        libpq-dev \
-        libpq5 \
         libssl-dev \
         libtool \
         libyajl-dev \

--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -21,10 +21,8 @@ RUN yum -y update \
         openssl-devel \
         perl-devel \
         perl-ExtUtils-Embed \
-        postgresql-devel \
         python-devel \
         rpm-build \
-        varnish-libs-devel \
         which \
         yajl-devel \
  && yum -y clean all

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -23,11 +23,9 @@ RUN yum -y update \
         perl-devel \
         perl-ExtUtils-Embed \
         pkgconfig \
-        postgresql-devel \
         python-devel \
         rpm-build \
         rpm-sign \
-        varnish-libs-devel \
         which \
         yajl-devel \
  && yum -y clean all

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -25,11 +25,9 @@ RUN yum -y update \
         perl-devel \
         perl-ExtUtils-Embed \
         pkgconfig \
-        postgresql-devel \
         python36-devel \
         rpm-build \
         rpm-sign \
-        varnish-libs-devel \
         which \
         yajl-devel \
  && yum -y clean all

--- a/build/x86_64_jessie/Dockerfile
+++ b/build/x86_64_jessie/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libtool \
         libyajl-dev \
         make \

--- a/build/x86_64_jessie/Dockerfile
+++ b/build/x86_64_jessie/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get -y update \
         libmysqlclient-dev \
         libpq-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_precise/Dockerfile
+++ b/build/x86_64_precise/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get -y update \
         libmysqlclient-dev \
         libpq-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_precise/Dockerfile
+++ b/build/x86_64_precise/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libtool \
         libyajl-dev \
         lsb-release \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -20,12 +20,10 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_
         libmysqlclient-devel \
         make \
         openssl-devel \
-        postgresql-devel \
         hiredis-devel \
         pkg-config \
         python-devel \
         rpm-build \
-        varnish-devel \
         wget \
         which \
  && wget https://ftp.gwdg.de/pub/opensuse/repositories/home%3A/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.92.1.noarch.rpm \

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -22,12 +22,10 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/
         libmysqlclient-devel \
         make \
         openssl-devel \
-        postgresql-devel \
         hiredis-devel \
         pkg-config \
         python-devel \
         rpm-build \
-        varnish-devel \
         wget \
         which \
  && wget https://ftp.gwdg.de/pub/opensuse/repositories/home%3A/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.92.1.noarch.rpm \

--- a/build/x86_64_stretch/Dockerfile
+++ b/build/x86_64_stretch/Dockerfile
@@ -17,8 +17,6 @@ RUN apt-get -y update \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
-        libpq-dev \
-        libpq5 \
         libssl1.0-dev \
         libtool \
         libyajl-dev \

--- a/build/x86_64_stretch/Dockerfile
+++ b/build/x86_64_stretch/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get -y update \
         libpq5 \
         libssl1.0-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_trusty/Dockerfile
+++ b/build/x86_64_trusty/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get -y update \
         libmysqlclient-dev \
         libpq-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_trusty/Dockerfile
+++ b/build/x86_64_trusty/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libtool \
         libyajl-dev \
         lsb-release \

--- a/build/x86_64_wheezy/Dockerfile
+++ b/build/x86_64_wheezy/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libtool \
         libyajl-dev \
         make \

--- a/build/x86_64_wheezy/Dockerfile
+++ b/build/x86_64_wheezy/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get -y update \
         libmysqlclient-dev \
         libpq-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_xenial/Dockerfile
+++ b/build/x86_64_xenial/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get -y update \
         libmysqlclient-dev \
         libpq-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_xenial/Dockerfile
+++ b/build/x86_64_xenial/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libtool \
         libyajl-dev \
         lsb-release \

--- a/deb/debian/controls/control.base
+++ b/deb/debian/controls/control.base
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, curl, libcurl3, libltdl7, libyajl2
-Suggests: default-jre, libhiredis0.10, libmysqlclient18, libpq5
+Suggests: default-jre, libhiredis0.10, libmysqlclient18
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/controls/control.base
+++ b/deb/debian/controls/control.base
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.bionic
+++ b/deb/debian/controls/control.bionic
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 10), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.13), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 10), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.13), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.bionic
+++ b/deb/debian/controls/control.bionic
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 10), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.13), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 10), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.13), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libcurl4, libltdl7, libyajl2
-Suggests: default-jre, libhiredis0.13, libmysqlclient20, libpq5
+Suggests: default-jre, libhiredis0.13, libmysqlclient20
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/controls/control.buster
+++ b/deb/debian/controls/control.buster
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libpq-dev, libssl-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libpq-dev, libssl-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.buster
+++ b/deb/debian/controls/control.buster
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libpq-dev, libssl-dev, libtool, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libssl-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, curl, libcurl4, libltdl7, libyajl2
-Suggests: default-jre, libhiredis0.13, libmariadbclient18, libpq5
+Suggests: default-jre, libhiredis0.13, libmariadbclient18
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/controls/control.jessie
+++ b/deb/debian/controls/control.jessie
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, curl, libcurl3, libltdl7, libyajl2
-Suggests: default-jre, libhiredis0.10, libmysqlclient18, libpq5
+Suggests: default-jre, libhiredis0.10, libmysqlclient18
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/controls/control.jessie
+++ b/deb/debian/controls/control.jessie
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.precise
+++ b/deb/debian/controls/control.precise
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.precise
+++ b/deb/debian/controls/control.precise
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, curl, libcurl3, libltdl7, libyajl1
-Suggests: default-jre, libhiredis0.10, libmysqlclient18, libpq5
+Suggests: default-jre, libhiredis0.10, libmysqlclient18
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/controls/control.stretch
+++ b/deb/debian/controls/control.stretch
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libpq-dev, libssl1.0-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libpq-dev, libssl1.0-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.stretch
+++ b/deb/debian/controls/control.stretch
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libpq-dev, libssl1.0-dev, libtool, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, default-libmysqlclient-dev, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libssl1.0-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, curl, libcurl3, libltdl7, libyajl2
-Suggests: default-jre, libhiredis0.13, libmariadbclient18, libpq5
+Suggests: default-jre, libhiredis0.13, libmariadbclient18
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/controls/control.xenial
+++ b/deb/debian/controls/control.xenial
@@ -3,7 +3,7 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libvarnishapi-dev, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any

--- a/deb/debian/controls/control.xenial
+++ b/deb/debian/controls/control.xenial
@@ -3,12 +3,12 @@ Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libpq-dev, libtool, libyajl-dev, lsb-release, pkg-config
+Build-Depends: autoconf, automake, debhelper (>= 7.0.50), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.10.0), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release, pkg-config
 
 Package: stackdriver-agent
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, curl, libcurl3, libltdl7, libyajl2
-Suggests: default-jre, libhiredis0.13, libmysqlclient20, libpq5
+Suggests: default-jre, libhiredis0.13, libmysqlclient20
 Description: Stackdriver system metrics collection daemon
   The Stackdriver system metrics daemon collects system statistics and
   sends them to the Stackdriver service.

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -20,12 +20,6 @@ ifeq ($(DISTRO),xenial)
 DOCKER_FLAG="--enable-docker"
 endif
 
-ifneq (,$(filter $(DISTRO),bionic buster))
-# Use system libmongoc where available.
-MONGO_FLAG=--enable-mongodb --with-libmongoc=yes
-else
-MONGO_FLAG=--enable-mongodb --with-libmongoc=own
-endif
 
 CFLAGS = -g
 
@@ -59,13 +53,11 @@ override_dh_auto_configure:
 	--enable-memcached \
 	--enable-mysql \
 	--enable-protocols \
-	--enable-postgresql \
 	--enable-plugin_mem \
 	--enable-processes \
 	--enable-python \
 	--enable-ntpd \
 	--enable-nfs \
-	--enable-zookeeper \
 	--enable-stackdriver_agent \
 	--enable-exec \
 	--enable-tail \
@@ -81,15 +73,13 @@ override_dh_auto_configure:
 	--enable-redis --with-libhiredis \
 	--enable-curl \
 	--enable-curl_json \
-	--enable-varnish \
 	--enable-write_gcm \
 	--enable-debug \
-	$(DOCKER_FLAG) \
-	$(MONGO_FLAG)
+	$(DOCKER_FLAG)
 
 # filter out shlib deps we don't want to force on people
 override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params="-x$(MYSQL) -xlibpq5 -x$(HIREDIS) -xlibvarnishapi1"
+	dh_shlibdeps --dpkg-shlibdeps-params="-x$(MYSQL) -xlibpq5 -x$(HIREDIS)"
 
 override_dh_strip:
 	dh_strip --dbg-package=stackdriver-agent

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -79,7 +79,7 @@ override_dh_auto_configure:
 
 # filter out shlib deps we don't want to force on people
 override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params="-x$(MYSQL) -xlibpq5 -x$(HIREDIS)"
+	dh_shlibdeps --dpkg-shlibdeps-params="-x$(MYSQL) -x$(HIREDIS)"
 
 override_dh_strip:
 	dh_strip --dbg-package=stackdriver-agent


### PR DESCRIPTION
Confirmed on CentOS 7 that adding configs for PostgreSQL, MongoDB, Varnish, and ZooKeeper cause the agent to fail to start (expected). The other deprecated applications use generic plugins (Plugin:GenericJMX = Cassandra, HBase, Kafka, Tomcat; Plugin:cURL-JSON = CouchDB, Elasticsearch, RabbitMQ, Riak) so those will still work. 
Also confirmed that the non-deprecated 3P applications still work as expected (Apache, JVM, Memcached, MySQL, Nginx, Redis).