### PR TITLE
Add build container Dockerfile for new OS distro Ubuntu 19.10 (Eoan).

### DIFF
--- a/build/x86_64_eoan/Dockerfile
+++ b/build/x86_64_eoan/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:eoan
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+ && apt-get install -y \
+        autoconf \
+        automake \
+        bison \
+        debhelper \
+        debian-keyring \
+        default-jdk \
+        devscripts \
+        flex \
+        gcc \
+        git \
+        libbson-dev \
+        libcurl4-openssl-dev \
+        libhiredis-dev \
+        libltdl-dev \
+        libmongoc-dev \
+        libmysqlclient-dev \
+        libpq-dev \
+        libssl-dev \
+        libtool \
+        libvarnishapi-dev \
+        libyajl-dev \
+        lsb-release \
+        make \
+        pkg-config \
+        python-dev \
+ && rm -rf /var/lib/apt/lists/*

--- a/build/x86_64_eoan/Dockerfile
+++ b/build/x86_64_eoan/Dockerfile
@@ -14,16 +14,12 @@ RUN apt-get update -y \
         flex \
         gcc \
         git \
-        libbson-dev \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
-        libmongoc-dev \
         libmysqlclient-dev \
-        libpq-dev \
         libssl-dev \
         libtool \
-        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \


### PR DESCRIPTION
$ docker build --no-cache -t jschulz/stackdriver-agent-build-container-x86_64_eoan .
...
Successfully built 289af1192448
Successfully tagged jschulz/stackdriver-agent-build-container-x86_64_eoan:latest