### PR TITLE
Truncate daemon name to less than 15 characters

### DIFF
--- a/deb/debian/stackdriver-agent.init
+++ b/deb/debian/stackdriver-agent.init
@@ -130,6 +130,8 @@ start() {
 #   1 if the daemon could not be stopped
 #   3 if the daemon was already stopped
 stop() {
+    DAEMON_NAME=${DAEMON##*/}
+    DAEMON_NAME=${DAEMON_NAME:0:15}
     killproc -p "$_PIDFILE" "$DAEMON"
 }
 

--- a/deb/debian/stackdriver-agent.init
+++ b/deb/debian/stackdriver-agent.init
@@ -132,7 +132,7 @@ start() {
 stop() {
     DAEMON_NAME=${DAEMON##*/}
     DAEMON_NAME=${DAEMON_NAME:0:15}
-    killproc -p "$_PIDFILE" "$DAEMON"
+    killproc -p "$_PIDFILE" "$DAEMON_NAME"
 }
 
 # return:


### PR DESCRIPTION
Due to kernel constraint, it can only take less than 15 chars. Debian 10 doesn't truncate. Therefore, we truncate it ourselves