### PR TITLE
Support new OS distro Ubuntu 20.04 (Focal).

### DIFF
--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -1,9 +1,8 @@
 FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -y \
- && apt-get install -y \
+RUN apt-get -y update \
+ && apt-get -y install \
         autoconf \
         automake \
         bison \

--- a/build/x86_64_eoan/Dockerfile
+++ b/build/x86_64_eoan/Dockerfile
@@ -1,9 +1,8 @@
 FROM ubuntu:eoan
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -y \
- && apt-get install -y \
+RUN apt-get -y update \
+ && apt-get -y install \
         autoconf \
         automake \
         bison \

--- a/build/x86_64_focal/Dockerfile
+++ b/build/x86_64_focal/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update \
+ && apt-get -y install \
+        autoconf \
+        automake \
+        bison \
+        debhelper \
+        debian-keyring \
+        default-jdk \
+        devscripts \
+        flex \
+        gcc \
+        git \
+        libcurl4-openssl-dev \
+        libhiredis-dev \
+        libltdl-dev \
+        libmysqlclient-dev \
+        libssl-dev \
+        libtool \
+        libyajl-dev \
+        lsb-release \
+        make \
+        pkg-config \
+        python-dev-is-python2 \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*

--- a/deb/debian/controls/control.focal
+++ b/deb/debian/controls/control.focal
@@ -1,0 +1,16 @@
+Source: stackdriver-agent
+Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+Build-Depends: autoconf, automake, debhelper (>= 10), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.14), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release, pkg-config
+
+Package: stackdriver-agent
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, libcurl4, libltdl7, libyajl2
+Suggests: default-jre, libhiredis0.14, libmysqlclient21
+Description: Stackdriver system metrics collection daemon
+  The Stackdriver system metrics daemon collects system statistics and
+  sends them to the Stackdriver service.
+  Currently includes collectd.
+

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -11,7 +11,7 @@ MYSQL=libmariadbclient18
 else ifneq (,$(filter $(DISTRO),xenial bionic))
 HIREDIS=libhiredis0.13
 MYSQL=libmysqlclient20
-else ifneq (,$(filter $(DISTRO),eoan))
+else ifneq (,$(filter $(DISTRO),eoan focal))
 HIREDIS=libhiredis0.14
 MYSQL=libmysqlclient21
 else


### PR DESCRIPTION
Adds build container Dockerfile, control file, and updates rules file.
Also a minor cleanup of the Bionic and Eoan build containers.