### PR TITLE
Remove hard-coded package versions from SLES build Dockerfiles.

### DIFF
--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,8 +1,10 @@
 FROM opensuse/leap:42.3
 
 RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/Apache.repo \
- # Add SLES 15 repo to install libhiredis0_13 from hiredis-devel
+ # Add SLES 15 repo to install libhiredis0_13 from hiredis-devel.
  && zypper addrepo https://download.opensuse.org/repositories/server:database/SLE_15/server:database.repo \
+ # Add Herbster0815 repo to install the latest automake.
+ && zypper addrepo https://download.opensuse.org/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.1/home:Herbster0815.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install \
         autoconf \
@@ -26,11 +28,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         pkg-config \
         python-devel \
         rpm-build \
-        wget \
         which \
- && wget https://ftp.gwdg.de/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.93.1.noarch.rpm \
- && rpm --force -Uvh automake-1.16.1-lp151.93.1.noarch.rpm \
- && rm automake-1.16.1-lp151.93.1.noarch.rpm \
  # Pretend we are on SLES 12.
  && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release \

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -1,8 +1,10 @@
 FROM opensuse/leap:15.1
 
 RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/c_c++/openSUSE_Leap_15.1/devel:libraries:c_c++.repo \
+ # Add Herbster0815 repo to install the latest automake.
+ && zypper addrepo https://download.opensuse.org/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.1/home:Herbster0815.repo \
  && zypper -n --gpg-auto-import-keys refresh \
- && zypper -n install \
+ && zypper -n install --allow-vendor-change \
         autoconf \
         automake \
         bison \
@@ -11,9 +13,9 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/
         gcc \
         git \
         java-1_8_0-openjdk-devel \
-        libcurl4-7.66.0-lp151.270.1.x86_64 \
+        libcurl4 \
         libcurl-devel \
-        libgcrypt20-1.8.5-lp151.161.1.x86_64 \
+        libgcrypt20 \
         libgcrypt-devel \
         libtool \
         libtool-ltdl-devel \
@@ -26,11 +28,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/
         pkg-config \
         python-devel \
         rpm-build \
-        wget \
         which \
- && wget https://ftp.gwdg.de/pub/opensuse/repositories/home%3A/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.92.1.noarch.rpm \
- && rpm --force -Uvh automake-1.16.1-lp151.92.1.noarch.rpm \
- && rm automake-1.16.1-lp151.92.1.noarch.rpm \
  # Pretend we are on SLES 15.
  && /bin/sed -i -e 's/VERSION="15.1"/VERSION="15-SP1"/' /etc/os-release \
  && zypper -n clean


### PR DESCRIPTION
Properly add the repo containing the correct automake version.

Fixes build errors resulting from stale package versions, e.g.:
```
Package 'libcurl4-7.66.0-lp151.270.1.x86_64' not found.
Package 'libgcrypt20-1.8.5-lp151.161.1.x86_64' not found.
```
on SLES 15 and:
```
https://ftp.gwdg.de/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.1/noarch/automake-1.16.1-lp151.93.1.noarch.rpm
...
HTTP request sent, awaiting response... 404 Not Found
```
on SLES 12.