### PR TITLE
Bump DATA_MAX_NAME_LEN to 256 in Linux packages.

### DIFF
--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -34,6 +34,8 @@ override_dh_auto_configure:
 	./clean.sh && ./build.sh
 	dh_auto_configure -- --prefix=/opt/stackdriver/collectd \
 	--program-prefix=stackdriver- \
+	--with-useragent="stackdriver_agent/$(debian_version)" \
+	--with-data-max-name-len=256 \
 	--disable-all-plugins \
 	--disable-static \
 	--disable-perl --without-libperl  --without-perl-bindings \
@@ -71,7 +73,6 @@ override_dh_auto_configure:
 	--enable-match_throttle_metadata_keys \
 	--enable-write_log \
 	--enable-unixsock \
-	--with-useragent="stackdriver_agent/$(debian_version)" \
 	--enable-java --with-java=/usr/lib/jvm/default-java \
 	--enable-redis --with-libhiredis \
 	--enable-curl \

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -239,6 +239,8 @@ export PATH=%{buildroot}/%{_prefix}/bin:$PATH
 
 %configure CFLAGS="%{optflags} -DLT_LAZY_OR_NOW='RTLD_NOW|RTLD_GLOBAL' %{?curl_include}" \
     --program-prefix=stackdriver- \
+    --with-useragent="stackdriver_agent/%{version}-%{release}" \
+    --with-data-max-name-len=256 \
     --disable-all-plugins \
     --disable-static \
     --disable-perl --without-libperl  --without-perl-bindings \
@@ -279,7 +281,6 @@ export PATH=%{buildroot}/%{_prefix}/bin:$PATH
     --enable-match_throttle_metadata_keys \
     --enable-write_log \
     --enable-unixsock \
-    --with-useragent="stackdriver_agent/%{version}-%{release}" \
     %{docker_flag} \
     %{java_flag} \
     %{redis_flag} \


### PR DESCRIPTION
Supersedes Stackdriver/collectd#186.