### PR TITLE
Remove references to nonexistent docker plugin.

### DIFF
--- a/collectd.conf
+++ b/collectd.conf
@@ -18,7 +18,6 @@ LoadPlugin syslog
 #  Timestamp true
 #</Plugin>
 
-# LoadPlugin docker
 LoadPlugin df
 <Plugin "df">
   FSType "devfs"

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -19,10 +19,6 @@ HIREDIS=libhiredis0.10
 MYSQL=libmysqlclient18
 endif
 
-ifeq ($(DISTRO),xenial)
-DOCKER_FLAG="--enable-docker"
-endif
-
 
 CFLAGS = -g
 
@@ -78,8 +74,7 @@ override_dh_auto_configure:
 	--enable-curl \
 	--enable-curl_json \
 	--enable-write_gcm \
-	--enable-debug \
-	$(DOCKER_FLAG)
+	--enable-debug
 
 # filter out shlib deps we don't want to force on people
 override_dh_shlibdeps:

--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -29,7 +29,6 @@
 %endif
 
 # some things that we enable or not based on distro version
-%define docker_flag --disable-docker
 %define has_yajl 1
 %define bundle_yajl 0
 %define has_hiredis 1
@@ -45,7 +44,6 @@
 %if 0%{?rhel} >= 7
 %define java_version 1.7.0
 %define curl_version 7.52.1
-%define docker_flag --enable-docker
 %define dep_filter 0
 %endif
 
@@ -281,7 +279,6 @@ export PATH=%{buildroot}/%{_prefix}/bin:$PATH
     --enable-match_throttle_metadata_keys \
     --enable-write_log \
     --enable-unixsock \
-    %{docker_flag} \
     %{java_flag} \
     %{redis_flag} \
     %{curl_json_flag} \


### PR DESCRIPTION
They reference a plugin from PR Stackdriver/collectd#96 that was never merged. A couple custom builds were made with it a few years ago and if anyone is using them (not sure how to find out), they are fixed to those set images (i.e. can't upgrade to current builds). 