### PR TITLE
Downgrade coreutils to 8.30 (from Ubuntu Focal) as 8.32 causes build path permission problem

### DIFF
--- a/build/x86_64_groovy/Dockerfile
+++ b/build/x86_64_groovy/Dockerfile
@@ -24,5 +24,8 @@ RUN apt-get -y update \
         make \
         pkg-config \
         python-dev-is-python2 \
+ && curl -sSO http://security.ubuntu.com/ubuntu/pool/main/c/coreutils/coreutils_8.30-3ubuntu2_amd64.deb \
+ && dpkg -i coreutils_8.30-3ubuntu2_amd64.deb \
+ && apt-get install -f \
  && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/*

--- a/build/x86_64_groovy/Dockerfile
+++ b/build/x86_64_groovy/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get -y update \
         make \
         pkg-config \
         python-dev-is-python2 \
- && curl -sSO http://security.ubuntu.com/ubuntu/pool/main/c/coreutils/coreutils_8.30-3ubuntu2_amd64.deb \
- && dpkg -i coreutils_8.30-3ubuntu2_amd64.deb \
- && apt-get install -f \
+ && echo 'deb http://archive.ubuntu.com/ubuntu/ focal main' >/etc/apt/sources.list.d/focal.list \
+ && apt-get -y update \
+ && apt-get -y install --allow-downgrades coreutils=8.30-3ubuntu2 \
  && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/*

--- a/build/x86_64_groovy/Dockerfile
+++ b/build/x86_64_groovy/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -y update \
         make \
         pkg-config \
         python-dev-is-python2 \
+ # Work around https://gitlab.archlinux.org/archlinux/archlinux-docker/-/issues/32.
  && echo 'deb http://archive.ubuntu.com/ubuntu/ focal main' >/etc/apt/sources.list.d/focal.list \
  && apt-get -y update \
  && apt-get -y install --allow-downgrades coreutils=8.30-3ubuntu2 \


### PR DESCRIPTION
Using the solution from https://gitlab.archlinux.org/archlinux/archlinux-docker/-/issues/32#note_1895.

Detailed debug info is listed in: b/169246004#comment13