### PR TITLE
Add control.groovy file for controlling required dependencies 

### DIFF
--- a/deb/debian/controls/control.groovy
+++ b/deb/debian/controls/control.groovy
@@ -1,0 +1,16 @@
+Source: stackdriver-agent
+Maintainer: Stackdriver Agents <stackdriver-agents@google.com>
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+Build-Depends: autoconf, automake, debhelper (>= 10), default-jdk, libcurl4-openssl-dev, libhiredis-dev (>= 0.14), libltdl-dev, libmysqlclient-dev, libtool, libyajl-dev, lsb-release, pkg-config
+
+Package: stackdriver-agent
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, libcurl4, libltdl7, libyajl2
+Suggests: default-jre, libhiredis0.14, libmysqlclient21
+Description: Stackdriver system metrics collection daemon
+  The Stackdriver system metrics daemon collects system statistics and
+  sends them to the Stackdriver service.
+  Currently includes collectd.
+  


### PR DESCRIPTION
Tested internally in b/169246004#comment16

File content is the same as control.focal