### PR TITLE
Update repo URLs for the deprecated CentOS 6 repos.

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -1,5 +1,11 @@
 FROM centos:6
 
+# CentOS 6 is EOL, so we have to switch to the vault repos.
+RUN sed -i \
+        -e 's%^mirrorlist%#mirrorlist%' \
+        -e 's%^# *baseurl=http://mirror%baseurl=http://vault%' \
+        /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum -y update \
  && yum -y install epel-release \
  && yum -y install \


### PR DESCRIPTION
CentOS 6 is now out-of-support, so the repos moved from `mirror.centos.org` to `vault.centos.org`.