### PR TITLE
Stop downloading unused curl

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -17,13 +17,7 @@ CURL_VERSION=7.52.1
 endif
 endif
 
-ifeq ($(filter sles%,$(DISTRO)),)  # If DISTRO is not sles*.
-vendor:
-	[ -f curl-$(CURL_VERSION).tar.bz2 ] || curl -O https://curl.haxx.se/download/curl-$(CURL_VERSION).tar.bz2
-	sha1sum -c curl-$(CURL_VERSION).sha1
-else
 vendor:;true
-endif
 
 TOPDIR=/root/rpmbuild
 

--- a/rpm/curl-7.34.0.sha1
+++ b/rpm/curl-7.34.0.sha1
@@ -1,1 +1,0 @@
-548fe1686d01d689f79ed8cedc879309f8f5035b  curl-7.34.0.tar.bz2

--- a/rpm/curl-7.52.1.sha1
+++ b/rpm/curl-7.52.1.sha1
@@ -1,1 +1,0 @@
-aa9f2300096d806c68c7ba8c50771853d1b43eb4  curl-7.52.1.tar.bz2


### PR DESCRIPTION
The sha1 of the downloaded curl is no longer matches the on in curl-7.34.0.sha1 (which seems suspicious). This PR stops downloading curl, as we don't seem to be using it