### PR TITLE
Update the stackdriver-agent service on SLES systems (#89)

### DIFF
--- a/rpm/stackdriver-agent.spec
+++ b/rpm/stackdriver-agent.spec
@@ -399,6 +399,7 @@ cp /usr/share/doc/yajl-1.0.7/COPYING yajl.COPYING
 %if 0%{?suse_version} > 0
 # Enable the service by default.
 %{fillup_and_insserv -f -y stackdriver-agent}
+systemctl daemon-reload
 %endif
 
 %preun


### PR DESCRIPTION
A cherry-pick of #89 into the legacy branch.