### PR TITLE
Fix CentOS/Amazon AMI build Dockerfiles.

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -1,8 +1,7 @@
 FROM amazonlinux:2016.09
 
 ADD http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el6/en/x86_64/rpmforge/RPMS/rpm-macros-rpmforge-0-6.el6.rf.noarch.rpm .
-RUN yum -y update \
- && yum -y install epel-release \
+RUN yum -y install epel-release \
  && yum -y install \
         autoconf \
         automake \

--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -6,8 +6,7 @@ RUN sed -i \
         -e 's%^# *baseurl=http://mirror%baseurl=http://vault%' \
         /etc/yum.repos.d/CentOS-*.repo
 
-RUN yum -y update \
- && yum -y install epel-release \
+RUN yum -y install epel-release \
  && yum -y install \
         autoconf \
         automake \

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -1,7 +1,6 @@
 FROM centos:7
 
-RUN yum -y update \
- && yum -y install epel-release \
+RUN yum -y install epel-release \
  && yum -y install \
         autoconf \
         automake \

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -1,8 +1,13 @@
 FROM centos:8
 
-RUN yum -y update \
- && dnf -y install 'dnf-command(config-manager)' \
- && yum config-manager --set-enabled PowerTools \
+# CentOS 8 is EOL, so we have to switch to the vault repos.
+RUN sed -i \
+        -e 's%^mirrorlist%#mirrorlist%' \
+        -e 's%^# *baseurl=http://mirror%baseurl=http://vault%' \
+        /etc/yum.repos.d/CentOS-*.repo
+
+RUN dnf -y install 'dnf-command(config-manager)' \
+ && yum config-manager --set-enabled powertools \
  && yum -y install epel-release \
  && yum -y install \
         autoconf \


### PR DESCRIPTION
- Remove stray `yum update` commands
- Redirect CentOS 8 mirrors to the vault
- Fix repository name on CentOS 8

See also GoogleCloudPlatform/google-fluentd#377