### PR TITLE
Update build container Dockerfiles to allow them to build again.

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2016.09
 
-ADD http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el6/en/x86_64/rpmforge/RPMS/rpm-macros-rpmforge-0-6.el6.rf.noarch.rpm .
+ADD https://rpmfind.net/linux/dag/redhat/el6/en/i386/dag/RPMS/rpm-macros-rpmforge-0-6.el6.rf.noarch.rpm .
 RUN yum -y install epel-release \
  && yum -y install \
         autoconf \

--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -22,9 +22,11 @@ RUN yum -y install epel-release \
         perl-devel \
         perl-ExtUtils-Embed \
         pkgconfig \
+        postgresql-devel \
         python-devel \
         rpm-build \
         rpm-sign \
+        varnish-libs-devel \
         which \
         yajl-devel \
  && rpm -Uvh rpm-macros-rpmforge*.rpm \

--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -13,12 +13,16 @@ RUN apt-get -y update \
         flex \
         gcc \
         git \
+        libbson-dev \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
+        libmongoc-dev \
         libmysqlclient-dev \
+        libpq-dev \
         libssl-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_buster/Dockerfile
+++ b/build/x86_64_buster/Dockerfile
@@ -17,8 +17,12 @@ RUN apt-get -y update \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
+        libmongoc-dev \
+        libpq-dev \
+        libpq5 \
         libssl-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -26,8 +26,10 @@ RUN yum -y install epel-release \
         openssl-devel \
         perl-devel \
         perl-ExtUtils-Embed \
+        postgresql-devel \
         python-devel \
         rpm-build \
+        varnish-libs-devel \
         which \
         yajl-devel \
  && yum -y clean all

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -22,9 +22,11 @@ RUN yum -y install epel-release \
         perl-devel \
         perl-ExtUtils-Embed \
         pkgconfig \
+        postgresql-devel \
         python-devel \
         rpm-build \
         rpm-sign \
+        varnish-libs-devel \
         which \
         yajl-devel \
  && yum -y clean all

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -30,9 +30,11 @@ RUN dnf -y install 'dnf-command(config-manager)' \
         perl-devel \
         perl-ExtUtils-Embed \
         pkgconfig \
+        postgresql-devel \
         python36-devel \
         rpm-build \
         rpm-sign \
+        varnish-libs-devel \
         which \
         yajl-devel \
  && yum -y clean all

--- a/build/x86_64_jessie/Dockerfile
+++ b/build/x86_64_jessie/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
+        libpq-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_precise/Dockerfile
+++ b/build/x86_64_precise/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
+        libpq-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,10 +1,15 @@
 FROM opensuse/leap:42.3
 
-RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/Apache.repo \
- # Add SLES 15 repo to install libhiredis0_13 from hiredis-devel.
- && zypper addrepo https://download.opensuse.org/repositories/server:database/SLE_15/server:database.repo \
+# Remove expired root certificate.
+RUN mv /var/lib/ca-certificates/pem/DST_Root_CA_X3.pem /etc/pki/trust/blacklist/ \
+ && update-ca-certificates
+
+RUN true \
+ # The 'OSS Update' repo signature is no longer valid, so verify the checksum instead.
+ && zypper --no-gpg-check refresh 'OSS Update' \
+ && (echo 'b889b4bba03074cd66ef9c0184768f4816d4ccb1fa9ec2721c5583304c5f23d0  /var/cache/zypp/raw/OSS Update/repodata/repomd.xml' | sha256sum --check) \
  # Add Herbster0815 repo to install the latest automake.
- && zypper addrepo https://download.opensuse.org/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.2/home:Herbster0815.repo \
+ && zypper addrepo https://download.opensuse.org/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.4/home:Herbster0815.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install \
         autoconf \
@@ -14,7 +19,6 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         flex \
         gcc \
         git \
-        hiredis-devel \
         java-1_7_0-openjdk-devel \
         libcurl-devel \
         libgcrypt-devel \
@@ -31,6 +35,8 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         rpm-build \
         varnish-devel \
         which \
+ # Use the SLES 15 repo to install libhiredis0_13 from hiredis-devel.
+ && zypper -n -p https://download.opensuse.org/distribution/leap/15.3/repo/oss/ install hiredis-devel \
  # Pretend we are on SLES 12.
  && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -14,6 +14,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         flex \
         gcc \
         git \
+        hiredis-devel \
         java-1_7_0-openjdk-devel \
         libcurl-devel \
         libgcrypt-devel \
@@ -24,10 +25,11 @@ RUN zypper addrepo https://download.opensuse.org/repositories/Apache/SLE_12_SP4/
         libmysqlclient-devel \
         make \
         openssl-devel \
-        hiredis-devel \
         pkg-config \
+        postgresql-devel \
         python-devel \
         rpm-build \
+        varnish-devel \
         which \
  # Pretend we are on SLES 12.
  && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -1,8 +1,10 @@
 FROM opensuse/leap:15.1
 
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/c_c++/openSUSE_Leap_15.1/devel:libraries:c_c++.repo \
+RUN zypper addrepo https://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/libraries:/c_c++/openSUSE_Leap_15.1/devel:libraries:c_c++.repo \
+ # The lysator.liu.se mirror still references download.opensuse.org.
+ && sed -i 's@download.opensuse.org@ftp.lysator.liu.se/pub/opensuse@' /etc/zypp/repos.d/devel_libraries_c_c++.repo \
  # Add Herbster0815 repo to install the latest automake.
- && zypper addrepo https://download.opensuse.org/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.2/home:Herbster0815.repo \
+ && zypper addrepo https://download.opensuse.org/pub/opensuse/repositories/home:/Herbster0815/openSUSE_Leap_15.4/home:Herbster0815.repo \
  && zypper -n --gpg-auto-import-keys refresh \
  && zypper -n install --allow-vendor-change \
         autoconf \

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -12,6 +12,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/
         flex \
         gcc \
         git \
+        hiredis-devel \
         java-1_8_0-openjdk-devel \
         libcurl4 \
         libcurl-devel \
@@ -24,10 +25,11 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:/libraries:/
         libmysqlclient-devel \
         make \
         openssl-devel \
-        hiredis-devel \
         pkg-config \
+        postgresql-devel \
         python-devel \
         rpm-build \
+        varnish-devel \
         which \
  # Pretend we are on SLES 15.
  && /bin/sed -i -e 's/VERSION="15.1"/VERSION="15-SP1"/' /etc/os-release \

--- a/build/x86_64_stretch/Dockerfile
+++ b/build/x86_64_stretch/Dockerfile
@@ -17,8 +17,11 @@ RUN apt-get -y update \
         libcurl4-openssl-dev \
         libhiredis-dev \
         libltdl-dev \
+        libpq-dev \
+        libpq5 \
         libssl1.0-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_trusty/Dockerfile
+++ b/build/x86_64_trusty/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
+        libpq-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \

--- a/build/x86_64_wheezy/Dockerfile
+++ b/build/x86_64_wheezy/Dockerfile
@@ -49,7 +49,9 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
+        libpq-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         make \
         pkg-config \

--- a/build/x86_64_xenial/Dockerfile
+++ b/build/x86_64_xenial/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get -y update \
         libhiredis-dev \
         libltdl-dev \
         libmysqlclient-dev \
+        libpq-dev \
         libtool \
+        libvarnishapi-dev \
         libyajl-dev \
         lsb-release \
         make \


### PR DESCRIPTION
This is a prerequisite for continuing work on #131.

Also restore some deprecated dependencies. This is part of the effort to switch to `master` as the source of truth for these. The dependencies are harmless, since they are not included unless explicitly enabling the plugins, but allows the legacy builds to proceed. This partially reverts #83 (only the build container part).