### PR TITLE
Use the Python 2 libraries in the CentOS 8 build container.

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2016.09
 
-ADD https://rpmfind.net/linux/dag/redhat/el6/en/i386/dag/RPMS/rpm-macros-rpmforge-0-6.el6.rf.noarch.rpm .
+ADD https://rpmfind.net/linux/dag/redhat/el6/en/x86_64/dag/RPMS/rpm-macros-rpmforge-0-6.el6.rf.noarch.rpm .
 RUN yum -y install epel-release \
  && yum -y install \
         autoconf \

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -31,7 +31,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
         perl-ExtUtils-Embed \
         pkgconfig \
         postgresql-devel \
-        python36-devel \
+        python2-devel \
         rpm-build \
         rpm-sign \
         varnish-libs-devel \


### PR DESCRIPTION
Also a cosmetic update to the URL in the amzn build container.
A follow-on to #132.