### PR TITLE
Update ca-certificates in the Amazon build container.

### DIFF
--- a/build/x86_64_amzn-2016.09/Dockerfile
+++ b/build/x86_64_amzn-2016.09/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install epel-release \
         autoconf \
         automake \
         bison \
+        ca-certificates \
         expect \
         flex \
         gcc \


### PR DESCRIPTION
Removing `yum update` in #128 caused the container to have outdated `ca-certificates`, which resulted in build failures like:
```
curl: (60) SSL certificate problem: certificate has expired
```