### PR TITLE
Fix bionic build container.

### DIFF
--- a/build/x86_64_bionic/Dockerfile
+++ b/build/x86_64_bionic/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -y update \
         lsb-release \
         make \
         pkg-config \
-        python2-dev \
+        python-dev \
         python3-dev \
  && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Python 2 is just python-dev on bionic.